### PR TITLE
add post to table post and postId to polling

### DIFF
--- a/databases/models/Polling.js
+++ b/databases/models/Polling.js
@@ -8,13 +8,13 @@ module.exports = (sequelize, DataTypes) => {
     }
 
     Polling.init({
-        polling_id : { type : DataTypes.UUID, allowNull : false, primaryKey : true},
+        polling_id : { type : DataTypes.UUID, primaryKey : true},
         post_id : { type : DataTypes.UUID},
         question : { type : DataTypes.STRING, allowNull : true },
         user_id : { type : DataTypes.STRING, allowNull : false},
         flg_multiple : { type : DataTypes.BOOLEAN, allowNull : false, defaultValue : false},
-        createdAt : { type: DataTypes.DATE, field: "created_at", allowNull: false},
-        updatedAt : { type: DataTypes.DATE, field: "updated_at", allowNull: true},
+        createdAt : { type: DataTypes.DATE, field: "created_at"},
+        updatedAt : { type: DataTypes.DATE, field: "updated_at"},
     }, {
         sequelize,
         modelName : "Polling",

--- a/databases/models/PollingOption.js
+++ b/databases/models/PollingOption.js
@@ -8,7 +8,7 @@ module.exports = (sequelize, DataTypes) => {
     }
 
     PollingOption.init({
-        polling_option_id : { type : DataTypes.UUID, allowNull : false, primaryKey : true},
+        polling_option_id : { type : DataTypes.UUID, primaryKey : true},
         polling_id : { type : DataTypes.UUID, allowNull : false },
         option : { type : DataTypes.STRING, allowNull : false },
         counter : { type : DataTypes.BIGINT, allowNull : true},

--- a/databases/models/Post.js
+++ b/databases/models/Post.js
@@ -1,0 +1,31 @@
+"use strict";
+const { Model } = require("sequelize");
+module.exports = (sequelize, DataTypes) => {
+    class Post extends Model {
+        static associate(models) {
+
+        }
+    }
+
+    Post.init({
+        post_id : { type : DataTypes.UUID, primaryKey : true},
+        author_user_id : { type : DataTypes.UUID, allowNull : false},
+        anonymous : { type : DataTypes.BOOLEAN, allowNull : false, defaultValue : false},
+        parent_post_id : { type : DataTypes.UUID},
+        audience_id : { type : DataTypes.STRING},
+        duration : { type : DataTypes.DATE},
+        audience_id : { type : DataTypes.UUID},
+        visibility_location_id : { type : DataTypes.STRING},
+        topic_id : { type : DataTypes.BIGINT, allowNull : false},
+        post_content : { type : DataTypes.STRING},
+        createdAt : { type: DataTypes.DATE, field: "created_at"},
+        updatedAt : { type: DataTypes.DATE, field: "updated_at"},
+    }, {
+        sequelize,
+        modelName : "Post",
+        tableName : "posts",
+        underscored : true
+    })
+
+    return Post
+}


### PR DESCRIPTION
1. On create poll, change all insert operation to raw query. Sequelize cannot insert null primary key meanwhile db in production has auto generated uuid.
2. The flow for inserting poll post is stated like this : 
- Insert to table post : get post_id,
- Insert into table polling with post_id : get polling_id,
- Insert into table polling_option with polling_id according to number of poll options : get respective polling_option_id
- Insert to get stream with additional attributes "polls" which has array of polling_option_id
