### PR TITLE
feat: PING-2529 uptime tracking endpoin

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -2,7 +2,8 @@ module.exports = {
   env: {
     browser: true,
     commonjs: true,
-    es2021: true
+    es2021: true,
+    jest: true
   },
   extends: ['airbnb-base', 'prettier'],
   overrides: [

--- a/app.js
+++ b/app.js
@@ -14,6 +14,7 @@ const bodyParser = require('body-parser');
 
 const swaggerApiDocumentation = require('./swagger/apiDocs.json');
 
+const statusHealthRoute = require('./routes/status-health');
 const topicsRouter = require('./routes/topics');
 const locationsRouter = require('./routes/locations');
 const whoToFollowRouter = require('./routes/whoToFollow');
@@ -64,6 +65,8 @@ app.use(bodyParser.json());
 app.use(express.urlencoded({extended: false, limit: '50mb'}));
 app.use(cookieParser());
 app.use(express.static(path.join(__dirname, 'public')));
+
+app.use('/status-health', statusHealthRoute);
 
 app.get('/debug-sentry', () => {
   throw new Error('My first Sentry error!');

--- a/package.json
+++ b/package.json
@@ -65,7 +65,8 @@
     "jest": "^27.0.3",
     "lint-staged": "^13.2.3",
     "nodemon": "^2.0.7",
-    "prettier": "^2.8.0"
+    "prettier": "^2.8.0",
+    "supertest": "^6.3.3"
   },
   "lint-staged": {
     "./**/*.{js,ts,jsx,tsx}": [

--- a/routes/status-health.js
+++ b/routes/status-health.js
@@ -1,0 +1,19 @@
+const express = require('express');
+const statusHealthService = require('../services/status-health.service');
+
+const router = express.Router();
+
+router.get('/ready', async (_req, res) => {
+  const isReady = await statusHealthService.isReady();
+  if (isReady) {
+    res.status(200).send();
+  } else {
+    res.status(503).json({message: 'Service unavailable'});
+  }
+});
+
+router.get('/live', async (_req, res) => {
+  res.status(200).send();
+});
+
+module.exports = router;

--- a/routes/status-health.test.js
+++ b/routes/status-health.test.js
@@ -1,0 +1,39 @@
+const request = require('supertest');
+const express = require('express');
+const statusHealthRoute = require('./status-health');
+const statusHealthService = require('../services/status-health.service');
+
+jest.mock('../services/status-health.service', () => ({
+  isReady: jest.fn()
+}));
+
+const app = express();
+app.use('/status-health', statusHealthRoute);
+
+describe('GET /status-health/live', () => {
+  it('should return 200 OK', async () => {
+    const response = await request(app).get('/status-health/live');
+    expect(response.statusCode).toBe(200);
+  });
+});
+
+describe('GET /status-health/ready', () => {
+  afterEach(() => {
+    statusHealthService.isReady.mockReset();
+  });
+
+  it('status-health check: ready should return 200 OK', async () => {
+    statusHealthService.isReady.mockResolvedValue(true);
+
+    const response = await request(app).get('/status-health/ready');
+    expect(response.statusCode).toBe(200);
+  });
+
+  it('status-health check: not ready should return 503 with Service unavailable response', async () => {
+    statusHealthService.isReady.mockResolvedValue(false);
+
+    const response = await request(app).get('/status-health/ready');
+    expect(response.statusCode).toBe(503);
+    expect(response.body).toEqual({message: 'Service unavailable'});
+  });
+});

--- a/services/status-health.service.js
+++ b/services/status-health.service.js
@@ -1,0 +1,30 @@
+const {redisClient} = require('../config/redis');
+const {getDb} = require('../databases/config/mongodb_conn');
+const {sequelize} = require('../databases/models');
+
+const statusHealthService = {
+  async isReady() {
+    try {
+      await this.checkRedis();
+      await this.checkMongoDb();
+      await this.checkPostgres();
+      return true;
+    } catch (err) {
+      return false;
+    }
+  },
+  async checkRedis() {
+    // based on https://github.com/redis/ioredis/blob/9c175502b53b400a31bd8bddc8e9a469856bc820/lib/Redis.ts#L176C1-L184C1
+    await redisClient.ping();
+  },
+  async checkMongoDb() {
+    const mongoDb = await getDb();
+    await mongoDb.command({ping: 1});
+  },
+  async checkPostgres() {
+    // check our sequelize
+    await sequelize.authenticate();
+  }
+};
+
+module.exports = statusHealthService;


### PR DESCRIPTION
1. Added `/status-health/live` endpoint to check liveness
2. Added `/status-health/ready` endpoint to check readiness (check for Redis, Mongodb and Postgres connection)
