### PR TITLE
chore: make integration test to take .env.test file and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,18 @@
 # user-api
+
 User Services API
 
 ## Get Started
 
 - After clone the project
 - Install dependency by running
+
 ```bash
 npm install
 ```
+
 - Run the app
+
 ```bash
 npm run dev
 ```
@@ -18,19 +22,34 @@ npm run dev
 ### Prerequisite
 
 1. set `EXECUTABLE_PHP` environment variable in `.env` file. you can run `which php` in your console to find it
+
 ```
 EXECUTABLE_PHP=/path/to/bin/php
 ```
 
 2. set `LARAVEL_PATH` environment variable in `.env` file. need to set fullpath to your laravel project that contain migration
+
 ```
 LARAVEL_PATH=/path/to/laravel
 ```
+
 3. you need to create database named "testing" in your Postgresdb
+4. open `.env.test` file. If you don't have this `.env.test` file, copy paste from `.env`
+5. Change these value in `.env.test`
+
+```
+DB_HOST=localhost
+DB_NAME=testing
+DB_PASSWORD=<your-postgresql-password>
+DB_USERNAME=<your-postgresql-username>
+// Add this value if you copy from .env file
+DB_SSL=false
+```
 
 ### Running Test
 
 1. To run api (integration) testing
+
 ```bash
 npm run test:api
 ```
@@ -40,10 +59,12 @@ npm run test:api
 - make sure you already have `.env` file (can see the `.env.example` for some connection to docker services)
 
 ### Prerequisite
+
 - Docker
 - Docker compose
 
 ### Whats in `docker-compose.yml`
+
 - user-api (this repository)
 - mongodb
 - redis
@@ -52,12 +73,15 @@ npm run test:api
 - docker network `bettersocial-devnetwork` (to let [queue repository](https://github.com/BetterSocial/bettersocial-dev-queue) docker-compose connected)
 
 ### Commands
+
 1. Start docker-compose
+
 ```bash
 docker-compose up -d
 ```
 
 2. getting into `user-api` bash console
+
 ```bash
 docker-compose exec user-api bash
 ```

--- a/__tests__/api/__setups__/env.js
+++ b/__tests__/api/__setups__/env.js
@@ -1,4 +1,6 @@
-require('dotenv').config();
+require('dotenv').config({
+  path: '.env.test'
+});
 
 Object.assign(process.env, {
   NODE_ENV: 'test',


### PR DESCRIPTION
This commit includes:
1. Making integration test to use .env.test file instead of .env file (reducing effort to switching env value when doing integration test on local).
2. Update README.md on prerequisites before running integration test.