### PR TITLE
fix: followers count

### DIFF
--- a/controllers/profiles/getOtherProfile.js
+++ b/controllers/profiles/getOtherProfile.js
@@ -40,11 +40,11 @@ module.exports = async (req, res) => {
     const isFollowingQuery = `SELECT * FROM user_follow_user WHERE user_id_followed= :user_id_followed AND user_id_follower= :user_id_follower`;
 
     const getFollowerCount = await sequelize.query(getFollowerCountQuery, {
-      replacements: {user_id: req.userId}
+      replacements: {user_id: other_user_id}
     });
 
     const getFollowingCount = await sequelize.query(getFollowingCountQuery, {
-      replacements: {user_id: req.userId}
+      replacements: {user_id: other_user_id}
     });
 
     const isFollowing = await sequelize.query(isFollowingQuery, {

--- a/controllers/profiles/getOtherProfileByUsername.js
+++ b/controllers/profiles/getOtherProfileByUsername.js
@@ -6,7 +6,7 @@ module.exports = async (req, res) => {
     const user = await User.findOne({
       where: {username: req.params.username},
       attributes: {
-        exclude: ['human_id']
+        exclude: ['human_id', 'is_backdoor_user', 'encrypted']
       }
     });
     if (user === null) {
@@ -17,20 +17,22 @@ module.exports = async (req, res) => {
       });
     }
 
+    const targetUserId = user?.dataValues?.user_id;
+
     const getFollowerCountQuery = `SELECT COUNT(user_follow_user.user_id_follower) as count_follower from user_follow_user WHERE user_id_followed = :user_id`;
     const getFollowingCountQuery = `SELECT COUNT(user_follow_user.user_id_followed) as count_following from user_follow_user WHERE user_id_follower = :user_id`;
     const isFollowingQuery = `SELECT * FROM user_follow_user WHERE user_id_followed= :user_id_followed AND user_id_follower= :user_id_follower`;
 
     const getFollowerCount = await sequelize.query(getFollowerCountQuery, {
-      replacements: {user_id: req.userId}
+      replacements: {user_id: targetUserId}
     });
 
     const getFollowingCount = await sequelize.query(getFollowingCountQuery, {
-      replacements: {user_id: req.userId}
+      replacements: {user_id: targetUserId}
     });
 
     const isFollowing = await sequelize.query(isFollowingQuery, {
-      replacements: {user_id_follower: req?.userId, user_id_followed: user?.dataValues?.user_id}
+      replacements: {user_id_follower: req?.userId, user_id_followed: targetUserId}
     });
 
     const getFollowerCountResult = getFollowerCount?.[0]?.[0]?.count_follower;

--- a/controllers/profiles/getProfileByName.js
+++ b/controllers/profiles/getProfileByName.js
@@ -27,7 +27,7 @@ module.exports = async (req, res) => {
       }
     });
 
-    if (!user)
+    if (!user || user?.dataValues)
       return res.json({
         code: 404,
         message: `No user with username ${username} found`,
@@ -53,8 +53,6 @@ module.exports = async (req, res) => {
     });
 
     const getFollowerCountResult = getFollowerCount?.[0]?.[0]?.count_follower;
-    console.log('getFollowerCountResult');
-    console.log(getFollowerCountResult);
     const getFollowingCountResult = getFollowingCount?.[0]?.[0]?.count_following;
     const isFollowingResult = isFollowing?.[0]?.length > 0;
 

--- a/controllers/profiles/getProfileByName.js
+++ b/controllers/profiles/getProfileByName.js
@@ -34,23 +34,27 @@ module.exports = async (req, res) => {
         status: 'error'
       });
 
+    const targetUserId = user?.dataValues?.user_id;
+
     const getFollowerCountQuery = `SELECT COUNT(user_follow_user.user_id_follower) as count_follower from user_follow_user WHERE user_id_followed = :user_id`;
     const getFollowingCountQuery = `SELECT COUNT(user_follow_user.user_id_followed) as count_following from user_follow_user WHERE user_id_follower = :user_id`;
     const isFollowingQuery = `SELECT * FROM user_follow_user WHERE user_id_followed= :user_id_followed AND user_id_follower= :user_id_follower`;
 
     const getFollowerCount = await sequelize.query(getFollowerCountQuery, {
-      replacements: {user_id: req.userId}
+      replacements: {user_id: targetUserId}
     });
 
     const getFollowingCount = await sequelize.query(getFollowingCountQuery, {
-      replacements: {user_id: req.userId}
+      replacements: {user_id: targetUserId}
     });
 
     const isFollowing = await sequelize.query(isFollowingQuery, {
-      replacements: {user_id_followed: user?.dataValues?.user_id, user_id_follower: req.userId}
+      replacements: {user_id_followed: targetUserId, user_id_follower: req.userId}
     });
 
     const getFollowerCountResult = getFollowerCount?.[0]?.[0]?.count_follower;
+    console.log('getFollowerCountResult');
+    console.log(getFollowerCountResult);
     const getFollowingCountResult = getFollowingCount?.[0]?.[0]?.count_following;
     const isFollowingResult = isFollowing?.[0]?.length > 0;
 

--- a/controllers/profiles/getProfileByName.js
+++ b/controllers/profiles/getProfileByName.js
@@ -27,7 +27,7 @@ module.exports = async (req, res) => {
       }
     });
 
-    if (!user || user?.dataValues)
+    if (!user?.dataValues)
       return res.json({
         code: 404,
         message: `No user with username ${username} found`,


### PR DESCRIPTION
this commit includes changes on user_follow_user.user_id_followed on 3 endpoints
1. /profiles/get-other-profile-by-username/:username
2./profiles/get-profile/:username
3./profiles/get-other-profile/:user-id
 


<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

---
- Bug Fix: Updated the logic for fetching follower and following counts in user profile related endpoints. This ensures accurate count based on the correct user.
- Refactor: Enhanced security by excluding additional sensitive fields (`is_backdoor_user` and `encrypted`) from the `User.findOne` query results.
- Chore: Added console logs for better tracking of `getFollowerCountResult` value.
---
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->