### PR TITLE
fix: create anonymous poll post schema

### DIFF
--- a/middlewares/body-validation/schema/createAnonymousPollPostV2Schema.js
+++ b/middlewares/body-validation/schema/createAnonymousPollPostV2Schema.js
@@ -1,5 +1,5 @@
 const Schema = {
-  message: 'string|empty:false',
+  message: 'string',
   verb: 'string|empty:false',
   feedGroup: 'string|empty:false',
   privacy: 'string|empty:false',


### PR DESCRIPTION
This commit fix "message" body validation to be able to accept empty string
<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

- Refactor: Updated the validation schema for creating anonymous polls. The "message" field in a post can now accept empty strings as valid values, providing more flexibility to users when they create polls.
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->