### PR TITLE
feat: set signed channel as read

### DIFF
--- a/__tests__/api/chat/channels/read.test.js
+++ b/__tests__/api/chat/channels/read.test.js
@@ -1,0 +1,91 @@
+const supertest = require('supertest');
+const app = require('../../../../app');
+const generateUserAndFollowSeeds = require('../../__utils__/seeds/users_and_follow_seeds');
+const {
+  createReusableAuthTestSuite,
+  createReusablePreventAnonymousUserTestSuite
+} = require('../../__authTest__/createReusableAuthTestSuite');
+
+beforeEach(() => {
+  generateUserAndFollowSeeds();
+});
+
+describe('POST /chat/channels/read', () => {
+  createReusableAuthTestSuite(
+    supertest(app)
+      .post('/api/v1/chat/channels/read')
+      .send({channelId: 'channel-id', channelType: 1})
+  );
+  createReusablePreventAnonymousUserTestSuite(
+    supertest(app)
+      .post('/api/v1/chat/channels/read')
+      .set({Authorization: 'Bearer anon-token'})
+      .send({channelId: 'channel-id', channelType: 1})
+  );
+
+  test('should return 403 error validation if channelId is not provided', async () => {
+    const response = await supertest(app)
+      .post('/api/v1/chat/channels/read')
+      .set({Authorization: `Bearer token`})
+      .send({
+        channelType: 1
+      })
+      .expect(403);
+
+    expect(response.body).toEqual(
+      expect.objectContaining({
+        status: 'error validation',
+        message: expect.arrayContaining([
+          expect.objectContaining({
+            field: 'channelId',
+            message: expect.any(String)
+          })
+        ])
+      })
+    );
+  });
+
+  test('should return 403 error validation if channel type is not provided', async () => {
+    const response = await supertest(app)
+      .post('/api/v1/chat/channels/read')
+      .set({Authorization: `Bearer token`})
+      .send({
+        channelId: 'channel-id'
+      })
+      .expect(403);
+
+    expect(response.body).toEqual(
+      expect.objectContaining({
+        status: 'error validation',
+        message: expect.arrayContaining([
+          expect.objectContaining({
+            field: 'channelType',
+            message: expect.any(String)
+          })
+        ])
+      })
+    );
+  });
+
+  test('should return 403 error validation if channelType is not chat or group', async () => {
+    const response = await supertest(app)
+      .post('/api/v1/chat/channels/read')
+      .set({Authorization: `Bearer token`})
+      .send({
+        message: 'Hello World',
+        channelType: 3
+      })
+      .expect(403);
+
+    expect(response.body).toEqual(
+      expect.objectContaining({
+        status: 'error validation',
+        message: expect.arrayContaining([
+          expect.objectContaining({
+            message: expect.any(String)
+          })
+        ])
+      })
+    );
+  });
+});

--- a/controllers/chat/setSignedChannelAsRead.js
+++ b/controllers/chat/setSignedChannelAsRead.js
@@ -1,0 +1,47 @@
+const {CHANNEL_TYPE} = require('../../helpers/constants');
+const GetstreamSingleton = require('../../vendor/getstream/singleton');
+
+const setSignedChannelAsRead = async (req, res) => {
+  const {channelType, channelId} = req.body;
+  let channelTypeDef;
+
+  switch (channelType) {
+    case CHANNEL_TYPE.CHAT:
+    case CHANNEL_TYPE.ANONYMOUS:
+      channelTypeDef = 'messaging';
+      break;
+
+    case CHANNEL_TYPE.GROUP:
+      channelTypeDef = 'group';
+      break;
+
+    default:
+      return res.status(403).json({
+        message: 'Error validation',
+        error: 'Channel type not found'
+      });
+  }
+
+  const client = GetstreamSingleton.getChatInstance();
+  try {
+    await client.connectUser({id: req.userId}, req.token);
+
+    const channel = client.channel(channelTypeDef, channelId);
+
+    await channel.watch();
+
+    const readed = await channel.markRead();
+
+    await client.disconnectUser();
+    return res.status(200).json({data: readed});
+  } catch (error) {
+    await client.disconnectUser();
+    return res.status(error.statusCode ?? error.status ?? 400).json({
+      status: 'error',
+      code: error.statusCode ?? error.status ?? 400,
+      message: error.message
+    });
+  }
+};
+
+module.exports = setSignedChannelAsRead;

--- a/middlewares/body-validation/index.js
+++ b/middlewares/body-validation/index.js
@@ -8,7 +8,6 @@ const GenerateBodyValidationMiddleware = (schema) => {
     try {
       const validate = v.validate(req?.body, schema);
       if (validate.length) {
-        console.log('error validation', validate);
         return res.status(403).json({
           code: 403,
           status: 'error validation',
@@ -69,6 +68,9 @@ const BodyValidationMiddleware = {
   registerV2: GenerateBodyValidationMiddleware(BodyValidationSchema.registerV2),
   registerV2WithoutUpload: GenerateBodyValidationMiddleware(
     BodyValidationSchema.registerV2WithoutUpload
+  ),
+  setSignedChannelAsRead: GenerateBodyValidationMiddleware(
+    BodyValidationSchema.setSignedChannelAsRead
   ),
   unblockUserV2: GenerateBodyValidationMiddleware(BodyValidationSchema.unblockUserV2),
   unfollowUserV2: GenerateBodyValidationMiddleware(BodyValidationSchema.unfollowUserV2),

--- a/middlewares/body-validation/schema/index.js
+++ b/middlewares/body-validation/schema/index.js
@@ -20,6 +20,7 @@ const BodyValidationSchema = {
   generatePostAnonymousUsername: require('./generatePostAnonymousUsernameSchema'),
   registerV2: require('./registerV2Schema'),
   registerV2WithoutUpload: require('./registerV2WithoutUploadSchema'),
+  setSignedChannelAsRead: require('./setSignedChannelAsReadSchema'),
   unblockUserV2: require('./unblockUserV2Schema'),
   unfollowUserV2: require('./unfollowUserV2Schema'),
   uploadPhoto: require('./uploadPhotoSchema'),

--- a/middlewares/body-validation/schema/setSignedChannelAsReadSchema.js
+++ b/middlewares/body-validation/schema/setSignedChannelAsReadSchema.js
@@ -1,0 +1,12 @@
+const {CHANNEL_TYPE} = require('../../../helpers/constants');
+
+const Schema = {
+  channelId: 'string|empty:false',
+  channelType: {
+    type: 'enum',
+    values: Object.values(CHANNEL_TYPE),
+    empty: false
+  }
+};
+
+module.exports = Schema;

--- a/routes/chat.js
+++ b/routes/chat.js
@@ -7,6 +7,8 @@ const auth = require('../middlewares/auth');
 const isTargetUserAllowingAnonDMMiddleware = require('../middlewares/chat/isTargetUserAllowingAnonDMMiddleware');
 const SuccessMiddleware = require('../middlewares/success');
 const sendSignedMessage = require('../controllers/chat/sendSignedMessage');
+const setSignedChannelAsRead = require('../controllers/chat/setSignedChannelAsRead');
+const BodyValidationMiddleware = require('../middlewares/body-validation');
 
 router.get('/create-channel', chatController.createChannel);
 router.post('/add-moderator', chatController.addChannelModerator);
@@ -19,6 +21,12 @@ router.get('/channels/:channelId', auth.isAuthAnonim, chatController.getChannel)
 router.post('/init-chat', auth.isAuth, chatController.initChat);
 router.post('/init-chat-anonymous', auth.isAuthAnonim, chatController.initChatAnonymous);
 router.post('/users/:targetUserId', auth.isAuth, chatController.getMyAnonProfile);
+router.post(
+  '/channels/read',
+  BodyValidationMiddleware.setSignedChannelAsRead,
+  auth.isAuthV2,
+  setSignedChannelAsRead
+);
 router.post('/channels/:channelId/read', auth.isAuthAnonim, chatController.readChannel);
 router.post(
   '/channels',


### PR DESCRIPTION
This commit includes:
1. Add separate endpoint for set signed channel as read /chat/channels/read
2. Add body validation middleware for /chat/channels/read
3. Remove console.log in body validation middleware
4. Add integrationt test for /chat/channels/read to prevent using anonymous token
5. Add body validation schema for /chat/channels/read
<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

- New Feature: Added a new endpoint `/chat/channels/read` to mark a signed channel as read. This feature enhances the user experience by allowing users to manage their chat notifications more effectively.
- Test: Introduced integration tests for the new endpoint, ensuring robustness and preventing misuse with anonymous tokens.
- Chore: Implemented body validation middleware for the new endpoint, improving security by validating incoming request data.
- Refactor: Removed unnecessary `console.log` statement from the body validation middleware, enhancing code cleanliness and performance.
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->