### PR TITLE
fix: add default value to user verified_status

### DIFF
--- a/databases/models/User.js
+++ b/databases/models/User.js
@@ -84,7 +84,11 @@ module.exports = (sequelize, DataTypes) => {
         type: DataTypes.BOOLEAN,
         defaultValue: false
       },
-      verified_status: {type: DataTypes.ENUM('VERIFIED', 'UNVERIFIED'), allowNull: false}
+      verified_status: {
+        type: DataTypes.ENUM('VERIFIED', 'UNVERIFIED'),
+        allowNull: false,
+        defaultValue: 'VERIFIED'
+      }
     },
     {
       sequelize,


### PR DESCRIPTION
This commits include:
1. Adding verified_status default value to 'VERIFIED', fixing many seeds that related user model.
<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

- New Feature: Updated the User model in our database. Now, when a new user record is created and no value for `verified_status` is provided, it will default to 'VERIFIED'. This change simplifies the user creation process and ensures consistency in our data handling.
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->