### PR TITLE
Fix/ping 2933 get all signed chat

### DIFF
--- a/__tests__/api/__setups__/utils.js
+++ b/__tests__/api/__setups__/utils.js
@@ -48,6 +48,7 @@ const createUser = async (data) => {
       real_name: 'test',
       last_active_at: new Date(),
       status: 'Y',
+      is_anonymous: false,
       ...data
     });
 

--- a/__tests__/api/chat/channels.test.js
+++ b/__tests__/api/chat/channels.test.js
@@ -3,13 +3,39 @@ const app = require('../../../app');
 const {createUser} = require('../__setups__/utils');
 const {StreamChat} = require('stream-chat');
 const jwt = require('jsonwebtoken');
+const GetstreamSingleton = require('../../../vendor/getstream/singleton');
 
 jest.mock('stream-chat');
 jest.mock('jsonwebtoken');
 
 afterEach(() => {
   jest.clearAllMocks();
+  GetstreamSingleton.reset();
 });
+
+const __generateQueryChannelsParamsCall = (userId, limit, offset) => {
+  return [{members: {$in: [userId]}}, [{last_message_at: -1}], {limit, offset, state: true}];
+};
+
+const __getSignedChannelListBodyExpectation = expect.objectContaining({
+  code: 200,
+  data: expect.arrayContaining([
+    expect.objectContaining({
+      members: expect.arrayContaining([expect.any(Object)]),
+      messages: expect.any(String)
+    })
+  ]),
+  status: 'Success retrieve channels'
+});
+
+const expectGetSignedChannelListFlow = (userId) => {
+  expect(jwt.verify).toHaveBeenCalled();
+  expect(StreamChat.getInstance).toHaveBeenCalled();
+  expect(StreamChat._instance).toBeInstanceOf(StreamChat);
+  expect(StreamChat._instance.connectUser).toHaveBeenCalledWith({id: userId}, 'valid-token');
+
+  expect(StreamChat._instance.disconnectUser).toHaveBeenCalled();
+};
 
 describe('GET /chat/channels/signed', () => {
   test('should return 200 OK with list of channels', async () => {
@@ -20,31 +46,88 @@ describe('GET /chat/channels/signed', () => {
       .set({Authorization: `Bearer valid-token`})
       .expect(200);
 
-    expect(response.body).toEqual(
-      expect.objectContaining({
-        code: 200,
-        data: expect.arrayContaining([
-          expect.objectContaining({
-            members: expect.arrayContaining([expect.any(Object)]),
-            messages: expect.any(String)
-          })
-        ]),
-        status: 'Success retrieve channels'
-      })
-    );
+    expect(response.body).toEqual(__getSignedChannelListBodyExpectation);
+    expectGetSignedChannelListFlow(user.user_id);
 
-    expect(jwt.verify).toHaveBeenCalled();
-    expect(StreamChat.getInstance).toHaveBeenCalled();
-    expect(StreamChat._instance).toBeInstanceOf(StreamChat);
-    expect(StreamChat._instance.connectUser).toHaveBeenCalledWith(
-      {id: user.user_id},
-      'valid-token'
+    expect(StreamChat._instance.queryChannels).toHaveBeenNthCalledWith(
+      1,
+      ...__generateQueryChannelsParamsCall(user.user_id, 30, 0)
     );
-    expect(StreamChat._instance.queryChannels).toHaveBeenCalledWith(
-      {members: {$in: [user.user_id]}},
-      [{last_message_at: -1}]
+    expect(StreamChat._instance.queryChannels).toHaveBeenNthCalledWith(
+      2,
+      ...__generateQueryChannelsParamsCall(user.user_id, 30, 30)
     );
-    expect(StreamChat._instance.disconnectUser).toHaveBeenCalled();
+    expect(StreamChat._instance.queryChannels).toHaveBeenNthCalledWith(
+      3,
+      ...__generateQueryChannelsParamsCall(user.user_id, 30, 60)
+    );
+    expect(StreamChat._instance.queryChannels).toHaveBeenNthCalledWith(
+      4,
+      ...__generateQueryChannelsParamsCall(user.user_id, 10, 90)
+    );
+  });
+
+  test('should return 200 OK with list of channels with offset only', async () => {
+    const user = await createUser();
+
+    const response = await request(app)
+      .get('/api/v1/chat/channels/signed?offset=10')
+      .set({Authorization: `Bearer valid-token`})
+      .expect(200);
+
+    expect(response.body).toEqual(__getSignedChannelListBodyExpectation);
+    expectGetSignedChannelListFlow(user.user_id);
+
+    expect(StreamChat._instance.queryChannels).toHaveBeenNthCalledWith(
+      1,
+      ...__generateQueryChannelsParamsCall(user.user_id, 30, 10)
+    );
+    expect(StreamChat._instance.queryChannels).toHaveBeenNthCalledWith(
+      2,
+      ...__generateQueryChannelsParamsCall(user.user_id, 30, 40)
+    );
+    expect(StreamChat._instance.queryChannels).toHaveBeenNthCalledWith(
+      3,
+      ...__generateQueryChannelsParamsCall(user.user_id, 30, 70)
+    );
+    expect(StreamChat._instance.queryChannels).toHaveBeenNthCalledWith(
+      4,
+      ...__generateQueryChannelsParamsCall(user.user_id, 10, 100)
+    );
+  });
+
+  test('should return 200 OK with list of channels with limit only', async () => {
+    const user = await createUser();
+
+    const response = await request(app)
+      .get('/api/v1/chat/channels/signed?limit=10')
+      .set({Authorization: `Bearer valid-token`})
+      .expect(200);
+
+    expect(response.body).toEqual(__getSignedChannelListBodyExpectation);
+    expectGetSignedChannelListFlow(user.user_id);
+
+    expect(StreamChat._instance.queryChannels).toHaveBeenNthCalledWith(
+      1,
+      ...__generateQueryChannelsParamsCall(user.user_id, 10, 0)
+    );
+  });
+
+  test('should return 200 OK with list of channels with limit and offset', async () => {
+    const user = await createUser();
+
+    const response = await request(app)
+      .get('/api/v1/chat/channels/signed?limit=10&offset=10')
+      .set({Authorization: `Bearer valid-token`})
+      .expect(200);
+
+    expect(response.body).toEqual(__getSignedChannelListBodyExpectation);
+    expectGetSignedChannelListFlow(user.user_id);
+
+    expect(StreamChat._instance.queryChannels).toHaveBeenNthCalledWith(
+      1,
+      ...__generateQueryChannelsParamsCall(user.user_id, 10, 10)
+    );
   });
 
   test('should return 401 Unauthorized', async () => {

--- a/__tests__/api/chat/channels/read.test.js
+++ b/__tests__/api/chat/channels/read.test.js
@@ -44,4 +44,26 @@ describe('POST /chat/channels/read', () => {
       })
     );
   });
+
+  test('should return 403 error validation if channel type is not provided', async () => {
+    const response = await supertest(app)
+      .post('/api/v1/chat/channels/read')
+      .set({Authorization: `Bearer token`})
+      .send({
+        channelId: 'channel-id'
+      })
+      .expect(403);
+
+    expect(response.body).toEqual(
+      expect.objectContaining({
+        status: 'error validation',
+        message: expect.arrayContaining([
+          expect.objectContaining({
+            field: 'channelType',
+            message: expect.any(String)
+          })
+        ])
+      })
+    );
+  });
 });

--- a/__tests__/api/chat/channels/read.test.js
+++ b/__tests__/api/chat/channels/read.test.js
@@ -66,26 +66,4 @@ describe('POST /chat/channels/read', () => {
       })
     );
   });
-
-  test('should return 403 error validation if channelType is not chat or group', async () => {
-    const response = await supertest(app)
-      .post('/api/v1/chat/channels/read')
-      .set({Authorization: `Bearer token`})
-      .send({
-        message: 'Hello World',
-        channelType: 3
-      })
-      .expect(403);
-
-    expect(response.body).toEqual(
-      expect.objectContaining({
-        status: 'error validation',
-        message: expect.arrayContaining([
-          expect.objectContaining({
-            message: expect.any(String)
-          })
-        ])
-      })
-    );
-  });
 });

--- a/__tests__/api/chat/send-signed-message.test.js
+++ b/__tests__/api/chat/send-signed-message.test.js
@@ -63,4 +63,26 @@ describe('POST /chat/send-signed-message', () => {
       })
     );
   });
+
+  test('should return 403 error validation if channelType is not chat or group', async () => {
+    const response = await supertest(app)
+      .post('/api/v1/chat/send-signed-message')
+      .set({Authorization: `Bearer token`})
+      .send({
+        message: 'Hello World',
+        channelType: 3
+      })
+      .expect(403);
+
+    expect(response.body).toEqual(
+      expect.objectContaining({
+        message: 'Error validation',
+        error: expect.arrayContaining([
+          expect.objectContaining({
+            message: expect.any(String)
+          })
+        ])
+      })
+    );
+  });
 });

--- a/controllers/chat/getSignedChannelList.js
+++ b/controllers/chat/getSignedChannelList.js
@@ -10,7 +10,7 @@ const __queryChannelBuilder = async (userId, limit, offset) => {
     offset: offset,
     state: true
   });
-  await client.disconnectUser();
+
   return channels;
 };
 
@@ -62,7 +62,6 @@ const getSignedChannelList = async (req, res) => {
       queriedChannels.push(...response);
     });
 
-    await client.disconnectUser();
     const channels = queriedChannels.map(__transformChannelData);
     return res.status(200).json(responseSuccess('Success retrieve channels', channels));
   } catch (error) {

--- a/controllers/chat/getSignedChannelList.js
+++ b/controllers/chat/getSignedChannelList.js
@@ -1,0 +1,73 @@
+const {responseSuccess} = require('../../utils/Responses');
+const GetstreamSingleton = require('../../vendor/getstream/singleton');
+
+const __queryChannelBuilder = async (userId, limit, offset) => {
+  console.log('querying channel', limit, offset);
+  const client = GetstreamSingleton.getChatInstance();
+  const channels = await client.queryChannels({members: {$in: [userId]}}, [{last_message_at: -1}], {
+    limit: limit,
+    offset: offset,
+    state: true
+  });
+  await client.disconnectUser();
+  return channels;
+};
+
+const getSignedChannelList = async (req, res) => {
+  const {userId} = req;
+  const {limit = 100, offset = 0} = req.query;
+
+  let totalFetched = 0;
+  const queriedChannels = [];
+  const promisedChannels = [];
+
+  const client = GetstreamSingleton.getChatInstance();
+  try {
+    await client.connectUser({id: req.userId}, req.token);
+
+    while (totalFetched < limit) {
+      const batchSize = Math.min(30, limit - totalFetched);
+      promisedChannels.push(
+        __queryChannelBuilder(userId, batchSize, Number(totalFetched) + Number(offset))
+      );
+      totalFetched += batchSize;
+      if (totalFetched >= limit) {
+        break;
+      }
+    }
+
+    const responses = await Promise.all(promisedChannels);
+    responses.forEach((response) => {
+      queriedChannels.push(...response);
+    });
+
+    await client.disconnectUser();
+    const channels = queriedChannels.map((channel) => {
+      const newChannel = {...channel.data};
+      delete newChannel.config;
+      delete newChannel.own_capabilities;
+
+      const members = [];
+      Object.keys(channel.state.members).forEach((member) => {
+        members.push(channel?.state?.members[member]);
+      });
+
+      return {
+        ...newChannel,
+        members,
+        unreadCount: channel.state.unreadCount,
+        messages: channel.state.messages
+      };
+    });
+    return res.status(200).json(responseSuccess('Success retrieve channels', channels));
+  } catch (error) {
+    await client.disconnectUser();
+    return res.status(error.statusCode ?? error.status ?? 400).json({
+      status: 'error',
+      code: error.statusCode ?? error.status ?? 400,
+      message: error.message
+    });
+  }
+};
+
+module.exports = getSignedChannelList;

--- a/middlewares/auth.js
+++ b/middlewares/auth.js
@@ -33,7 +33,7 @@ module.exports.isAuth = async (req, res, next) => {
   try {
     const tokenPayload = await isAuthTokenValid(token, process.env.SECRET);
     const user = await UsersFunction.findUserById(User, tokenPayload.user_id);
-    UsersFunction.updateLastActiveAt(User, user?.user_id);
+    await UsersFunction.updateLastActiveAt(User, user?.user_id);
     req.user = user;
     req.userId = user.user_id;
     req.token = token;

--- a/middlewares/body-validation/index.js
+++ b/middlewares/body-validation/index.js
@@ -42,6 +42,7 @@ const BodyValidationMiddleware = {
   ),
   changeBio: GenerateBodyValidationMiddleware(BodyValidationSchema.changeBio),
   changeProfileImage: GenerateBodyValidationMiddleware(BodyValidationSchema.changeProfileImage),
+  commonLimitOffset: GenerateBodyValidationMiddleware(BodyValidationSchema.commonLimitOffset),
   createAnonymousCommentChildV2: GenerateBodyValidationMiddleware(
     BodyValidationSchema.createAnonymousCommentChildV2
   ),

--- a/middlewares/body-validation/schema/commonLimitOffsetSchema.js
+++ b/middlewares/body-validation/schema/commonLimitOffsetSchema.js
@@ -1,0 +1,6 @@
+const Schema = {
+  limit: 'number|optional:true',
+  offset: 'number|optional:true'
+};
+
+module.exports = Schema;

--- a/middlewares/body-validation/schema/index.js
+++ b/middlewares/body-validation/schema/index.js
@@ -7,6 +7,7 @@ const BodyValidationSchema = {
   checkHumanIdExchangeToken: require('./checkHumanIdExchangeToken'),
   checkPasswordForDemoLogin: require('./checkPasswordForDemoLoginSchema'),
   checkUserFollowStatus: require('./checkUserFollowStatusSchema'),
+  commonLimitOffset: require('./commonLimitOffsetSchema'),
   createAnonymousCommentChildV2: require('./createAnonymousCommentChildV2Schema'),
   createAnonymousCommentV2: require('./createAnonymousCommentV2Schema'),
   createAnonymousPollPostV2: require('./createAnonymousPollPostV2Schema'),

--- a/routes/chat.js
+++ b/routes/chat.js
@@ -9,6 +9,7 @@ const SuccessMiddleware = require('../middlewares/success');
 const sendSignedMessage = require('../controllers/chat/sendSignedMessage');
 const setSignedChannelAsRead = require('../controllers/chat/setSignedChannelAsRead');
 const BodyValidationMiddleware = require('../middlewares/body-validation');
+const getSignedChannelList = require('../controllers/chat/getSignedChannelList');
 
 router.get('/create-channel', chatController.createChannel);
 router.post('/add-moderator', chatController.addChannelModerator);
@@ -16,7 +17,12 @@ router.post('/add-members-channel', auth.isAuth, chatController.addMembers);
 router.post('/anonymous', auth.isAuthAnonim, chatController.sendAnonymous);
 router.post('/send-signed-message', auth.isAuthV2, sendSignedMessage);
 router.get('/channels', auth.isAuthAnonim, chatController.getChannels);
-router.get('/channels/signed', auth.isAuthV2, chatController.getChannels);
+router.get(
+  '/channels/signed',
+  BodyValidationMiddleware.commonLimitOffset,
+  auth.isAuthV2,
+  getSignedChannelList
+);
 router.get('/channels/:channelId', auth.isAuthAnonim, chatController.getChannel);
 router.post('/init-chat', auth.isAuth, chatController.initChat);
 router.post('/init-chat-anonymous', auth.isAuthAnonim, chatController.initChatAnonymous);

--- a/vendor/getstream/singleton/index.js
+++ b/vendor/getstream/singleton/index.js
@@ -42,7 +42,10 @@ const GetstreamSingleton = (() => {
      * @returns {StreamChat}
      */
     getChatInstance: () => {
-      chatInstance = createChatInstance();
+      if (!chatInstance) {
+        chatInstance = createChatInstance();
+      }
+
       return chatInstance;
     },
 
@@ -53,6 +56,12 @@ const GetstreamSingleton = (() => {
     getClientInstance: (clientToken) => {
       clientInstance = createClientInstance(clientToken);
       return clientInstance;
+    },
+
+    reset: () => {
+      instance = null;
+      clientInstance = null;
+      chatInstance = null;
     }
   };
 })();


### PR DESCRIPTION
This commits include:
1. Add unread count on get signed chat list
2. Add limit offset on get signed chat list
3. Separate get signed chat list and get anonymous chat list
4. Remove unstable test



<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

- New Feature: Introduced a new API endpoint `/channels/signed` to fetch signed chat list with added functionalities like unread count and limit/offset pagination.
- Refactor: Separated the "get signed chat list" and "get anonymous chat list" functionalities for better modularity.
- Test: Added test cases for the new API endpoint and updated existing ones. Removed unstable tests.
- New Feature: Implemented a common body validation middleware for validating limit and offset parameters in request bodies.
- Chore: Updated the `createUser` function in test setups to include the `is_anonymous` field.
- Bug Fix: Ensured the `updateLastActiveAt` function in the authentication middleware is awaited properly, improving reliability.
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->