### PR TITLE
fix: skip expired post and get next feed

### DIFF
--- a/services/block/BlockServices.js
+++ b/services/block/BlockServices.js
@@ -11,7 +11,6 @@ class BlockServices {
   getHasBlock(post) {
     try {
       let newArr = this.#privateProcessBlock(post);
-      console.log(newArr);
       return this.#processAnonymousBlock(newArr);
     } catch (err) {
       console.log(err);

--- a/services/getstream/GetstreamService.js
+++ b/services/getstream/GetstreamService.js
@@ -1,4 +1,3 @@
-const stream = require('getstream');
 const InvariantError = require('../../exceptions/InvariantError');
 const {MAX_FEED_FETCH_LIMIT, GETSTREAM_RANKING_METHOD} = require('../../helpers/constants');
 
@@ -12,7 +11,7 @@ class GetstreamService {
     const query = {
       limit,
       reactions: {own: true, recent: true, counts: true},
-      // ranking: GETSTREAM_RANKING_METHOD,
+      ranking: GETSTREAM_RANKING_METHOD,
       offset
     };
     const res = await this._client.feed('topic', id).get(query);

--- a/utils/post.js
+++ b/utils/post.js
@@ -12,6 +12,7 @@ const {
   Sequelize
 } = require('../databases/models');
 const {NO_POLL_OPTION_UUID, POST_TYPE_LINK, POST_VERB_POLL} = require('../helpers/constants');
+const deleteActivityFromUserFeed = require('../services/getstream/deleteActivityFromUserFeed');
 
 /**
  *
@@ -309,14 +310,19 @@ function modifyReactionsPost(post, isAnonimous = true) {
   return newPost;
 }
 
-async function filterFeeds(userId, feeds = []) {
+async function filterFeeds(userId, feeds = [], feed_id = null) {
   const newResult = [];
 
   for (const item of feeds || []) {
     const now = moment().valueOf();
     const dateExpired = moment(item?.expired_at).valueOf();
 
-    if (dateExpired < now) continue;
+    if (dateExpired < now) {
+      if (feed_id) {
+        deleteActivityFromUserFeed('topic', feed_id, item.id);
+      }
+      continue;
+    }
     let newItem = {...item};
 
     if (newItem.anonimity) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

- New Feature: Enhanced the feed retrieval process with the addition of `getFeedTopicPages` method, improving the efficiency and accuracy of topic page fetching.
- New Feature: Introduced `modifiedFeed` method to handle specific post objects with a "poll" verb, enhancing the versatility of post object handling.
- Refactor: Updated `getTopicPages` method to utilize the new `getFeedTopicPages` and `modifiedFeed` methods, optimizing the topic page retrieval and processing.
- Bug Fix: Improved the `filterFeeds` function by adding a new parameter `feed_id` and implementing logic to delete expired activities from the user feed, ensuring up-to-date and relevant user feeds.
- Chore: Removed unnecessary console.log statement from the `BlockServices` class for cleaner code execution.
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->