### PR TITLE
fix: user anonymous created at and updated at is not set to constant

### DIFF
--- a/__tests__/api/__setups__/utils.js
+++ b/__tests__/api/__setups__/utils.js
@@ -1,6 +1,7 @@
 const {exec} = require('child_process');
 const {User} = require('../../../databases/models');
 const TestConstants = require('../__utils__/constant');
+const moment = require('moment');
 
 if (process.env.EXECUTABLE_PHP === undefined) {
   throw new Error('Please set EXECUTABLE_PHP env');
@@ -49,6 +50,8 @@ const createUser = async (data) => {
       last_active_at: new Date(),
       status: 'Y',
       is_anonymous: false,
+      created_at: moment.utc().format('YYYY-MM-DD HH:mm:ss'),
+      updated_at: moment.utc().format('YYYY-MM-DD HH:mm:ss'),
       verified_status: 'VERIFIED',
       ...data
     });

--- a/__tests__/api/chat/channels/read.test.js
+++ b/__tests__/api/chat/channels/read.test.js
@@ -6,8 +6,8 @@ const {
   createReusablePreventAnonymousUserTestSuite
 } = require('../../__authTest__/createReusableAuthTestSuite');
 
-beforeEach(() => {
-  generateUserAndFollowSeeds();
+beforeEach(async () => {
+  await generateUserAndFollowSeeds();
 });
 
 describe('POST /chat/channels/read', () => {

--- a/__tests__/api/chat/send-signed-message.test.js
+++ b/__tests__/api/chat/send-signed-message.test.js
@@ -6,8 +6,8 @@ const {
 } = require('../__authTest__/createReusableAuthTestSuite');
 const generateUserAndFollowSeeds = require('../__utils__/seeds/users_and_follow_seeds');
 
-beforeEach(() => {
-  generateUserAndFollowSeeds();
+beforeEach(async () => {
+  await generateUserAndFollowSeeds();
 });
 
 describe('POST /chat/send-signed-message', () => {

--- a/databases/functions/users/users-register-anonymous.js
+++ b/databases/functions/users/users-register-anonymous.js
@@ -5,7 +5,7 @@ const CryptoUtils = require('../../../utils/crypto');
 
 /**
  *
- * @param {Model} model
+ * @param {import('sequelize').Model} model
  * @param {String} userId
  * @param {Transaction} transaction
  */

--- a/databases/functions/users/users-register-anonymous.js
+++ b/databases/functions/users/users-register-anonymous.js
@@ -1,7 +1,6 @@
 const {v4: uuidv4} = require('uuid');
 const moment = require('moment');
 const crypto = require('crypto');
-const {Transaction} = require('sequelize');
 const CryptoUtils = require('../../../utils/crypto');
 
 /**
@@ -19,26 +18,24 @@ module.exports = async (model, userId, transaction = null) => {
   const anonymousUsername = crypto.createHash('sha256').update(saltedUserId).digest('hex');
   const encryptedUserId = CryptoUtils.encryptSignedUserId(userId);
   const userIdAnonymous = uuidv4();
-  const user = await model.create(
-    {
-      user_id: userIdAnonymous,
-      human_id: userIdAnonymous,
-      country_code: '',
-      username: anonymousUsername,
-      real_name: '',
-      profile_pic_path: '',
-      profile_pic_asset_id: '',
-      profile_pic_public_id: '',
-      createdAt: myTs,
-      updatedAt: myTs,
-      last_active_at: myTs,
-      status: 'Y',
-      bio: '',
-      is_anonymous: true,
-      encrypted: encryptedUserId
-    },
-    {transaction, returning: true}
-  );
+  const userPayload = {
+    user_id: userIdAnonymous,
+    human_id: userIdAnonymous,
+    country_code: '',
+    username: anonymousUsername,
+    real_name: '',
+    profile_pic_path: '',
+    profile_pic_asset_id: '',
+    profile_pic_public_id: '',
+    created_at: myTs,
+    updated_at: myTs,
+    last_active_at: myTs,
+    status: 'Y',
+    bio: '',
+    is_anonymous: true,
+    encrypted: encryptedUserId
+  };
+  const user = await model.create(userPayload, {transaction, returning: true});
 
   return user;
 };

--- a/databases/models/User.js
+++ b/databases/models/User.js
@@ -91,8 +91,7 @@ module.exports = (sequelize, DataTypes) => {
       },
       updated_at: {
         type: 'TIMESTAMP',
-        allowNull: false,
-        defaultValue: '2023-01-01 00:00:00'
+        allowNull: false
       },
       created_at: {
         type: 'TIMESTAMP',
@@ -104,6 +103,7 @@ module.exports = (sequelize, DataTypes) => {
       sequelize,
       modelName: 'User',
       tableName: 'users',
+      timestamps: false,
       createdAt: 'created_at',
       updatedAt: 'updated_at'
     }

--- a/databases/models/User.js
+++ b/databases/models/User.js
@@ -88,6 +88,16 @@ module.exports = (sequelize, DataTypes) => {
         type: DataTypes.ENUM('VERIFIED', 'UNVERIFIED'),
         allowNull: false,
         defaultValue: 'VERIFIED'
+      },
+      updated_at: {
+        type: 'TIMESTAMP',
+        allowNull: false,
+        defaultValue: '2023-01-01 00:00:00'
+      },
+      created_at: {
+        type: 'TIMESTAMP',
+        allowNull: false,
+        defaultValue: '2023-01-01 00:00:00'
       }
     },
     {


### PR DESCRIPTION
This commit include
1. Disable timestamp for user creation on sequelize
2. Add default timestamp for created_at 

<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

- Refactor: Updated user creation process to manually handle timestamp generation, improving consistency across different time zones.
- Test: Fixed potential race conditions in chat-related test suites by ensuring user and follow seeds are fully generated before each test case execution. This enhances the reliability of our tests.
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->