### PR TITLE
fix: following value not returned on my profile

### DIFF
--- a/controllers/profiles/getMyProfile.js
+++ b/controllers/profiles/getMyProfile.js
@@ -38,7 +38,7 @@ module.exports = async (req, res) => {
     const getFollowerCountResult = getFollowerCount?.[0]?.[0]?.count_follower;
     const getFollowingCountResult = getFollowingCount?.[0]?.[0]?.count_following;
 
-    delete copyUser.following;
+    copyUser.following = parseInt(getFollowingCountResult || 0);
     delete copyUser.follower;
 
     copyUser.following_symbol = checkMoreOrLess(getFollowingCountResult);


### PR DESCRIPTION
This commit includes:
1. Fix get my profile endpoint not returning the following value
<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

- Bug Fix: Updated the 'Get My Profile' endpoint to accurately reflect the number of users being followed. This change ensures that the user's profile information returned includes the correct count of followed users, enhancing the accuracy of user data and improving the overall user experience.
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->