### PR TITLE
fix: try catch on updatepartial when user has no sufficient role

### DIFF
--- a/controllers/chat/findOrCreateChannelBySignedSender.js
+++ b/controllers/chat/findOrCreateChannelBySignedSender.js
@@ -28,13 +28,18 @@ const findOrCreateChannelBySignedSender = async (req, res) => {
 
     const findOrCreateChannel = await channel.create();
     const channelName = findOrCreateChannel.members.map((member) => member.user.name).join(', ');
-    await channel.updatePartial({
-      set: {
-        channelType,
-        channel_type: channelType,
-        name: channelName
-      }
-    });
+
+    try {
+      await channel.updatePartial({
+        set: {
+          channelType,
+          channel_type: channelType,
+          name: channelName
+        }
+      });
+    } catch (e) {
+      console.debug(e);
+    }
 
     await client.disconnectUser();
 


### PR DESCRIPTION
This commit includes:
1. Add try catch so find or create signed channel not failing when actor doesn't have sufficient role.
<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

- Bug Fix: Enhanced error handling in the chat functionality. We've added a try-catch block around the `channel.updatePartial()` function within `findOrCreateChannelBySignedSender.js`. This change ensures that any exceptions occurring during the update process are properly caught and logged, preventing potential disruptions to the chat service. Users can now enjoy a more stable and reliable chat experience.
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->