### PR TITLE
chore: change channel detail wording

### DIFF
--- a/controllers/chat/changeChannelDetail.js
+++ b/controllers/chat/changeChannelDetail.js
@@ -18,7 +18,7 @@ const changeChannelDetail = async (req, res) => {
     members: {$in: [userId]}
   });
 
-  if (queriedChannel?.length < 1) return ErrorResponse.e404(res, 'Channel not found');
+  if (queriedChannel?.length < 1) return ErrorResponse.e404(res, 'Group not found');
 
   const channel = await client.channel(CHANNEL_TYPE_STRING.GROUP, channel_id);
   const updateData = {};
@@ -34,7 +34,7 @@ const changeChannelDetail = async (req, res) => {
 
     return res.status(200).json({
       status: 'success',
-      message: 'Channel updated'
+      message: 'Group has been updated'
     });
   } catch (e) {
     return ErrorResponse.e500(res, e.message);


### PR DESCRIPTION
This commit includes
1. Change wording on change channel detail 
<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

- Refactor: Updated the response message in `changeChannelDetail` function. The message now accurately reflects that a "Group" has been updated instead of a "Channel". This change enhances the clarity of communication to the end-user when they modify group details.
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->