### PR TITLE
fix: add is_self param in post

### DIFF
--- a/controllers/feeds/detailFeed.js
+++ b/controllers/feeds/detailFeed.js
@@ -6,6 +6,8 @@ const {NO_POLL_OPTION_UUID, POST_TYPE_POLL} = require('../../helpers/constants')
 const {getDetailFeed} = require('../../services/getstream');
 const {responseSuccess} = require('../../utils/Responses');
 const ErrorResponse = require('../../utils/response/ErrorResponse');
+const UsersFunction = require('../../databases/functions/users');
+const {User} = require('../../databases/models');
 
 module.exports = async (req, res) => {
   const {id} = req.query;
@@ -22,7 +24,11 @@ module.exports = async (req, res) => {
     return ErrorResponse.e404(res, 'This post has expired and has been deleted automatically');
   }
 
+  const myAnonymousUser = await UsersFunction.findAnonymousUserId(User, req.userId, {raw: true});
+
   const newItem = {...feedItem};
+  newItem.is_self =
+    newItem.actor.id === req.userId || newItem.actor.id === myAnonymousUser?.user_id;
   const client = stream.connect(process.env.API_KEY, process.env.SECRET, process.env.APP_ID);
 
   if (newItem.anonimity) {

--- a/controllers/profiles/getSelfAnonymousFeedsInProfile.js
+++ b/controllers/profiles/getSelfAnonymousFeedsInProfile.js
@@ -1,12 +1,11 @@
-const moment = require('moment');
-const {POST_VERB_POLL, MAX_FEED_FETCH_LIMIT} = require('../../helpers/constants');
-const {DomainPage, User} = require('../../databases/models');
+const {MAX_FEED_FETCH_LIMIT} = require('../../helpers/constants');
+const {User} = require('../../databases/models');
 
 const UsersFunction = require('../../databases/functions/users');
 const Getstream = require('../../vendor/getstream');
 const ErrorResponse = require('../../utils/response/ErrorResponse');
 const SuccessResponse = require('../../utils/response/SuccessResponse');
-const {modifyPollPostObject, modifyPostLinkPost, filterFeeds} = require('../../utils/post');
+const {filterFeeds} = require('../../utils/post');
 
 module.exports = async (req, res) => {
   try {
@@ -16,7 +15,11 @@ module.exports = async (req, res) => {
     if (!anonymousUserId) return ErrorResponse.e404(res, 'Anonymous user not found');
 
     const result = await Getstream.feed.getAnonymousFeeds(anonymousUserId?.user_id, limit, offset);
-    const newResult = await filterFeeds(req?.userId, result?.results || []);
+    const newResult = await filterFeeds(
+      req?.userId,
+      anonymousUserId?.user_id,
+      result?.results || []
+    );
 
     const responseData = {
       feeds: newResult,

--- a/controllers/profiles/getSelfFeedsInProfile.js
+++ b/controllers/profiles/getSelfFeedsInProfile.js
@@ -1,20 +1,16 @@
 const getstreamService = require('../../services/getstream');
-const moment = require('moment');
-const {
-  POST_VERB_POLL,
-  MAX_FEED_FETCH_LIMIT,
-  GETSTREAM_TIME_LINEAR_RANKING_METHOD
-} = require('../../helpers/constants');
-const {DomainPage} = require('../../databases/models');
+const {MAX_FEED_FETCH_LIMIT} = require('../../helpers/constants');
+const {User} = require('../../databases/models');
 
 const _ = require('lodash');
-const {modifyPostLinkPost, modifyPollPostObject, filterFeeds} = require('../../utils/post');
+const {filterFeeds} = require('../../utils/post');
+const UsersFunction = require('../../databases/functions/users');
 
 module.exports = async (req, res) => {
   let {limit = MAX_FEED_FETCH_LIMIT, offset = 0} = req.query;
-  let domainPageCache = {};
 
   const token = req.token;
+  const myAnonymousUser = await UsersFunction.findAnonymousUserId(User, req.userId);
 
   getstreamService
     .getFeeds(token, 'user_excl', {
@@ -25,7 +21,7 @@ module.exports = async (req, res) => {
     })
 
     .then(async (result) => {
-      let data = await filterFeeds(req?.userId, result?.results || []);
+      let data = await filterFeeds(req?.userId, myAnonymousUser?.user_id, result?.results || []);
 
       res.status(200).json({
         code: 200,

--- a/utils/post.js
+++ b/utils/post.js
@@ -333,7 +333,13 @@ const modifyNewItemAnonymity = (newItem) => {
   return newItem;
 };
 
-async function filterFeeds(userId, feeds = [], feed_id = null, threshold = null) {
+async function filterFeeds(
+  userId,
+  selfAnonymousUserId,
+  feeds = [],
+  feed_id = null,
+  threshold = null
+) {
   const results = await Promise.all(
     feeds.map(async (item) => {
       const expired = isExpiredPost(item);
@@ -345,6 +351,8 @@ async function filterFeeds(userId, feeds = [], feed_id = null, threshold = null)
         return null;
       }
       let newItem = {...item};
+
+      newItem.is_self = item?.actor?.id === userId || item?.actor?.id === selfAnonymousUserId;
 
       newItem = modifyNewItemAnonymity(newItem);
       newItem = modifyReactionsPost(newItem, newItem.anonimity);


### PR DESCRIPTION
This commit includes:
1. Add is_self field on several post fetch like get main feeds, get self feeds in profile, get self anonymous feeds, get topic feeds, get feed by id
<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

- New Feature: Added `is_self` field to post objects, enabling users to identify if a post belongs to them or an anonymous user associated with their account. This change affects the fetch functions in various controllers including feeds and profiles.
- Refactor: Updated the `filterFeeds` function to accept an additional parameter `anonymousUserId`, enhancing the functionality to filter feeds based on both user ID and anonymous user ID.
- Chore: Removed unused imports and functions from several files for better code maintainability and performance.
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->