### PR TITLE
feat: return community data in get all signed chat list

### DIFF
--- a/controllers/chat/getSignedChannelList.js
+++ b/controllers/chat/getSignedChannelList.js
@@ -79,9 +79,6 @@ const __filterAndTransformChannelData = async (channel, userId) => {
       removePrefixTopic(newChannel.id)
     );
 
-    console.log(`topic name ${removePrefixTopic(newChannel.id)}`);
-    console.log(topic);
-
     newChannel.image = topic?.icon_path || null;
     newChannel.channelImage = topic?.icon_path || null;
     newChannel.channel_image = topic?.icon_path || null;

--- a/controllers/chat/getSignedChannelList.js
+++ b/controllers/chat/getSignedChannelList.js
@@ -1,7 +1,7 @@
 const {StreamChat} = require('stream-chat');
 const {responseSuccess} = require('../../utils/Responses');
 const {CHANNEL_TYPE} = require('../../helpers/constants');
-const {Topics} = require('../../databases/models');
+const {sequelize} = require('../../databases/models');
 const TopicFunction = require('../../databases/functions/topics');
 const {removePrefixTopic} = require('../../utils/custom');
 
@@ -62,7 +62,7 @@ const __queryChannelBuilder = async (client, userId, limit, offset) => {
  * @param {import('stream-chat').Channel} channel
  * @returns
  */
-const __filterAndTransformChannelData = async (channel) => {
+const __filterAndTransformChannelData = async (channel, userId) => {
   const newChannel = {...channel.data};
   delete newChannel.config;
   delete newChannel.own_capabilities;
@@ -73,10 +73,21 @@ const __filterAndTransformChannelData = async (channel) => {
   if (messageLength === 0 && channelType === CHANNEL_TYPE.TOPIC) return false;
 
   if (channelType === CHANNEL_TYPE.TOPIC) {
-    const topic = await TopicFunction.findOneByName(Topics, removePrefixTopic(newChannel.id));
-    newChannel.image = topic.icon_path || null;
-    newChannel.channelImage = topic.icon_path || null;
-    newChannel.channel_image = topic.icon_path || null;
+    const topic = await TopicFunction.getTopicDetailByTopicId(
+      sequelize,
+      userId,
+      removePrefixTopic(newChannel.id)
+    );
+
+    console.log(`topic name ${removePrefixTopic(newChannel.id)}`);
+    console.log(topic);
+
+    newChannel.image = topic?.icon_path || null;
+    newChannel.channelImage = topic?.icon_path || null;
+    newChannel.channel_image = topic?.icon_path || null;
+    newChannel.cover_image = topic?.cover_path || null;
+    newChannel.is_following = topic?.is_following || false;
+    newChannel.topic_follower_count = parseInt(topic?.topic_follower_count || 0);
   }
 
   const members = [];
@@ -128,7 +139,7 @@ const getSignedChannelList = async (req, res) => {
     const channels = [];
     for (let i = 0; i < queriedChannels.length; i++) {
       const _channelItem = queriedChannels[i];
-      const _filteredChannel = await __filterAndTransformChannelData(_channelItem);
+      const _filteredChannel = await __filterAndTransformChannelData(_channelItem, userId);
 
       if (_filteredChannel) channels.push(_filteredChannel);
     }

--- a/databases/functions/topics/index.js
+++ b/databases/functions/topics/index.js
@@ -1,6 +1,7 @@
 const TopicFunction = {
   findAllByTopicIds: require('./topic-find-all-by-ids'),
-  findOneByName: require('./topic-find-one-by-name')
+  findOneByName: require('./topic-find-one-by-name'),
+  getTopicDetailByTopicId: require('./topic-get-topic-detail-by-id')
 };
 
 module.exports = TopicFunction;

--- a/databases/functions/topics/topic-get-topic-detail-by-id.js
+++ b/databases/functions/topics/topic-get-topic-detail-by-id.js
@@ -1,0 +1,35 @@
+const {QueryTypes} = require('sequelize');
+
+const getTopicDetailById = async (sequelize, selfUserId, topicName) => {
+  const query = `SELECT 
+      topics.*, 
+      COUNT(user_topics.topic_id) as topic_follower_count, 
+      CASE COALESCE(user_following_topics.user_id, '') 
+        WHEN '' THEN false
+        ELSE true
+      END as is_following
+    FROM topics
+    LEFT JOIN user_topics
+      ON user_topics.topic_id = topics.topic_id
+    LEFT JOIN user_topics AS user_following_topics
+      ON user_following_topics.topic_id = topics.topic_id AND user_following_topics.user_id=:selfUserId
+    WHERE topics.name=:topicName
+    GROUP BY user_topics.topic_id, topics.topic_id, user_following_topics.user_id`;
+
+  try {
+    const response = await sequelize.query(query, {
+      type: QueryTypes.SELECT,
+      replacements: {
+        selfUserId,
+        topicName
+      }
+    });
+
+    return response[0];
+  } catch (error) {
+    console.log(error);
+    throw new Error(error);
+  }
+};
+
+module.exports = getTopicDetailById;

--- a/databases/functions/topics/topic-get-topic-detail-by-id.js
+++ b/databases/functions/topics/topic-get-topic-detail-by-id.js
@@ -25,10 +25,11 @@ const getTopicDetailById = async (sequelize, selfUserId, topicName) => {
       }
     });
 
-    return response[0];
+    return response?.[0];
   } catch (error) {
-    console.log(error);
-    throw new Error(error);
+    console.error('Error on fetching topic detail');
+    console.error(error);
+    return null;
   }
 };
 


### PR DESCRIPTION
This commit includes:
1. Add new topic function to get topic detail, is self following, and topic_follower_count
2. Change topic data fetching in get all signed chat list

<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

- New Feature: Enhanced the chat functionality by integrating topic details into the "get all signed chat list" feature. This provides users with more comprehensive information about each chat channel.
- New Feature: Added a new function `getTopicDetailById` that fetches detailed information about a specific topic, including follower count and the user's follow status. This will improve the user experience when interacting with topics.
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->