### PR TITLE
fix: add is following in feeds

### DIFF
--- a/controllers/feeds/getFeedsV2.js
+++ b/controllers/feeds/getFeedsV2.js
@@ -16,7 +16,8 @@ const {
   modifyPollPostObject,
   modifyAnonimityPost,
   isPostBlocked,
-  modifyReactionsPost
+  modifyReactionsPost,
+  modifyFeedIsFollowingTarget
 } = require('../../utils/post');
 const {DomainPage, Locations, User} = require('../../databases/models');
 const RedisDomainHelper = require('../../services/redis/helper/RedisDomainHelper');
@@ -180,7 +181,8 @@ module.exports = async (req, res) => {
           } else {
             item.is_self =
               item.actor.id === req.userId || item.actor.id === myAnonymousUser?.user_id;
-            let newItem = await modifyAnonimityPost(item);
+            let newItem = await modifyFeedIsFollowingTarget(item, req.userId);
+            newItem = await modifyAnonimityPost(newItem);
             newItem = modifyReactionsPost(newItem, newItem.anonimity);
             if (item.verb === POST_VERB_POLL) {
               const postPoll = await modifyPollPostObject(req.userId, item);

--- a/controllers/profiles/getOtherFeedsInProfile.js
+++ b/controllers/profiles/getOtherFeedsInProfile.js
@@ -2,35 +2,17 @@ const getstreamService = require('../../services/getstream');
 const {
   POST_VERB_POLL,
   MAX_FEED_FETCH_LIMIT,
-  NO_POLL_OPTION_UUID,
-  BLOCK_FEED_KEY,
-  BLOCK_POST_ANONYMOUS,
-  GETSTREAM_RANKING_METHOD,
   MAX_GET_FEED_FROM_GETSTREAM_ITERATION,
   MAX_DATA_RETURN_LENGTH,
   POST_TYPE_LINK,
   GETSTREAM_TIME_LINEAR_RANKING_METHOD
 } = require('../../helpers/constants');
-const {
-  PollingOption,
-  LogPolling,
-  sequelize,
-  UserFollowUser,
-  DomainPage
-} = require('../../databases/models');
-const {Op} = require('sequelize');
-const {getListBlockUser, getListBlockPostAnonymous} = require('../../services/blockUser');
-const getBlockDomain = require('../../services/domain/getBlockDomain');
-const _ = require('lodash');
-const lodash = require('lodash');
-const {setData, getValue, delCache} = require('../../services/redis');
-const {convertString} = require('../../utils/custom');
+const {UserFollowUser, DomainPage} = require('../../databases/models');
 const {modifyPollPostObject} = require('../../utils/post');
 const RedisDomainHelper = require('../../services/redis/helper/RedisDomainHelper');
 
 module.exports = async (req, res) => {
   let {offset = 0, limit = MAX_FEED_FETCH_LIMIT} = req.query;
-  let domainPageCache = {};
 
   let getFeedFromGetstreamIteration = 0;
   let data = [];
@@ -77,6 +59,8 @@ module.exports = async (req, res) => {
         if (now < dateExpired || item.duration_feed == 'never') {
           let newItem = {...item};
           if (item.anonimity) continue;
+
+          newItem.is_following_target = userFollow ? true : false;
           if (item.verb === POST_VERB_POLL) {
             newItem = await modifyPollPostObject(req.userId, item);
             data.push(newItem);


### PR DESCRIPTION
This commit includes:
1. Add is_following_target param in all get feeds scenario
2. Add new post utils to modify post is following target
<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

- New Feature: Added a new parameter `is_following_target` to the feed items in the `get feeds` scenario. This will allow users to see if they are following the author of a particular feed item.
- Refactor: Updated the order of function calls in getFeedsV2.js for better data consistency. The `is_following_target` is now updated before modifying the anonymity of the post.
- New Feature: Introduced a new utility function `modifyFeedIsFollowingTarget` in utils/post.js. This function checks and updates the `is_following_target` status for each feed item, enhancing user experience by providing more relevant information.
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->