### PR TITLE
feat: add karma score on topic follower list

### DIFF
--- a/controllers/topics/index.js
+++ b/controllers/topics/index.js
@@ -191,6 +191,7 @@ const getFollowerList = async (req, res) => {
         users.username,
         users.bio,
         users.profile_pic_path,
+        users.karma_score,
         users.created_at,
         users.updated_at,
         is_following_subquery.user_id_follower,


### PR DESCRIPTION
add karma score on topic follower list
<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

- New Feature: Enhanced the `getFollowerList` function in the Topics controller. Now, when retrieving the list of followers for a specific topic, the response will also include each follower's `karma_score`. This update provides users with more comprehensive information about their topic followers, allowing them to better understand the influence and reputation of their audience within the platform.
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->