### PR TITLE
Feat/ping 3481 follow unfollow blurred status

### DIFF
--- a/controllers/feeds/getFeeds.js
+++ b/controllers/feeds/getFeeds.js
@@ -104,7 +104,6 @@ module.exports = async (req, res) => {
           if (now < dateExpired || item.duration_feed == 'never') {
             const isBlurredPost = await UserFollowUserFunction.checkIsBlurredPost(
               UserFollowUser,
-              User,
               req.userId
             );
             let newItem = await modifyAnonimityPost(item, isBlurredPost);

--- a/controllers/feeds/getFeedsV2.js
+++ b/controllers/feeds/getFeedsV2.js
@@ -123,7 +123,7 @@ module.exports = async (req, res) => {
       getListBlockUser(req.userId),
       getBlockDomain(req.userId),
       getListBlockPostAnonymousAuthor(req.userId),
-      UserFollowUserFunction.checkIsBlurredPost(UserFollowUser, User, req.userId)
+      UserFollowUserFunction.checkIsBlurredPost(UserFollowUser, req.userId)
     ]);
 
     const listAnonymousAuthor = listPostAnonymousAuthor.map(

--- a/controllers/feeds/getFeedsV2.js
+++ b/controllers/feeds/getFeedsV2.js
@@ -19,10 +19,11 @@ const {
   modifyReactionsPost,
   modifyFeedIsFollowingTarget
 } = require('../../utils/post');
-const {DomainPage, Locations, User} = require('../../databases/models');
+const {DomainPage, Locations, User, UserFollowUser} = require('../../databases/models');
 const RedisDomainHelper = require('../../services/redis/helper/RedisDomainHelper');
 const {ACTIVITY_THRESHOLD} = require('../../config/constant');
 const UsersFunction = require('../../databases/functions/users');
+const UserFollowUserFunction = require('../../databases/functions/userFollowUser');
 
 const getActivtiesOnFeed = async (feed, token, paramGetFeeds) => {
   console.log('Get activity from getstream => ', feed, paramGetFeeds);
@@ -110,11 +111,20 @@ module.exports = async (req, res) => {
 
   try {
     const {token} = req;
-    const myAnonymousUser = await UsersFunction.findAnonymousUserId(User, req.userId, {raw: true});
-    // START get excluded post parameter
-    const listBlockUser = await getListBlockUser(req.userId);
-    const listBlockDomain = await getBlockDomain(req.userId);
-    const listPostAnonymousAuthor = await getListBlockPostAnonymousAuthor(req.userId);
+    const [
+      myAnonymousUser,
+      // START get excluded post parameter
+      listBlockUser,
+      listBlockDomain,
+      listPostAnonymousAuthor,
+      isBlurredPost
+    ] = await Promise.all([
+      UsersFunction.findAnonymousUserId(User, req.userId, {raw: true}),
+      getListBlockUser(req.userId),
+      getBlockDomain(req.userId),
+      getListBlockPostAnonymousAuthor(req.userId),
+      UserFollowUserFunction.checkIsBlurredPost(UserFollowUser, User, req.userId)
+    ]);
 
     const listAnonymousAuthor = listPostAnonymousAuthor.map(
       (value) => value.post_anonymous_author_id
@@ -182,7 +192,7 @@ module.exports = async (req, res) => {
             item.is_self =
               item.actor.id === req.userId || item.actor.id === myAnonymousUser?.user_id;
             let newItem = await modifyFeedIsFollowingTarget(item, req.userId);
-            newItem = await modifyAnonimityPost(newItem);
+            newItem = await modifyAnonimityPost(newItem, isBlurredPost);
             newItem = modifyReactionsPost(newItem, newItem.anonimity);
             if (item.verb === POST_VERB_POLL) {
               const postPoll = await modifyPollPostObject(req.userId, item);

--- a/controllers/profiles/followAnonUser.js
+++ b/controllers/profiles/followAnonUser.js
@@ -36,6 +36,11 @@ module.exports = async (req, res) => {
     return ErrorResponse.e403(res, 'Error - requires anonymous userID');
   }
 
+  const isBlurredPost = await UserFollowUserFunction.checkIsBlurredPost(
+    UserFollowUser,
+    req?.userId
+  );
+
   try {
     await sequelize.transaction(async (t) => {
       const userFollowUser = await UserFollowUserFunction.registerAddFollowUser(
@@ -106,6 +111,7 @@ module.exports = async (req, res) => {
   }
 
   return SuccessResponse(res, {
-    message: 'User has been followed successfully'
+    message: 'User has been followed successfully',
+    isBlurredPost
   });
 };

--- a/controllers/profiles/followUserV3.js
+++ b/controllers/profiles/followUserV3.js
@@ -28,6 +28,11 @@ module.exports = async (req, res) => {
     return ErrorResponse.e404(res, 'User not found');
   }
 
+  const isBlurredPost = await UserFollowUserFunction.checkIsBlurredPost(
+    UserFollowUser,
+    req?.userId
+  );
+
   try {
     await sequelize.transaction(async (t) => {
       const userFollowUser = await UserFollowUserFunction.registerAddFollowUser(
@@ -109,6 +114,7 @@ module.exports = async (req, res) => {
   }
 
   return SuccessResponse(res, {
-    message: 'User has been followed successfully'
+    message: 'User has been followed successfully',
+    isBlurredPost
   });
 };

--- a/controllers/profiles/unfollowAnonUser.js
+++ b/controllers/profiles/unfollowAnonUser.js
@@ -36,6 +36,11 @@ module.exports = async (req, res) => {
   )
     return ErrorResponse.e409(res, 'You have not followed this user');
 
+  const isBlurredPost = await UserFollowUserFunction.checkIsBlurredPost(
+    UserFollowUser,
+    req?.userId
+  );
+
   try {
     await sequelize.transaction(async (t) => {
       const userFollowUser = await UserFollowUserFunction.userUnfollow(
@@ -81,6 +86,7 @@ module.exports = async (req, res) => {
   }
 
   return SuccessResponse(res, {
-    message: 'User has been unfollowed successfully'
+    message: 'User has been unfollowed successfully',
+    isBlurredPost
   });
 };

--- a/controllers/profiles/unfollowUserV3.js
+++ b/controllers/profiles/unfollowUserV3.js
@@ -25,6 +25,11 @@ module.exports = async (req, res) => {
   )
     return ErrorResponse.e409(res, 'You have not followed this user');
 
+  const isBlurredPost = await UserFollowUserFunction.checkIsBlurredPost(
+    UserFollowUser,
+    req?.userId
+  );
+
   try {
     await sequelize.transaction(async (t) => {
       const userFollowUser = await UserFollowUserFunction.userUnfollow(
@@ -86,6 +91,7 @@ module.exports = async (req, res) => {
   }
 
   return SuccessResponse(res, {
-    message: 'User has been unfollowed successfully'
+    message: 'User has been unfollowed successfully',
+    isBlurredPost
   });
 };

--- a/databases/functions/userFollowUser/check-is-blurred-post.js
+++ b/databases/functions/userFollowUser/check-is-blurred-post.js
@@ -1,43 +1,20 @@
-const findAnonymousUserId = require('../users/find-anonymous-user-id');
-
 /**
  *
  * @param {Model} userFollowUserModel
  * @param {RegisterBodyData.Users} users
  */
-module.exports = async (userFollowUserModel, userModel, userIdFollower, _transaction = null) => {
+module.exports = async (userFollowUserModel, _userModel, userIdFollower, _transaction = null) => {
   let isBlurredPost = false;
 
-  let [signUserList, anonUserList] = await Promise.all([
-    userFollowUserModel.findAll({
-      where: {
-        user_id_follower: userIdFollower,
-        is_anonymous: false
-      },
-      raw: true
-    }),
-    userFollowUserModel.findAll({
-      where: {
-        user_id_follower: userIdFollower,
-        is_anonymous: true
-      },
-      raw: true
-    })
-  ]);
-
-  let anonUserFromSignList = [];
-  await Promise.all(
-    signUserList.map(async (user) => {
-      let anonUserFromSign = await findAnonymousUserId(userModel, user.user_id_followed);
-      anonUserFromSignList.push(anonUserFromSign.user_id);
-    })
-  );
-
-  let anonUserWithoutSignUser = anonUserList.filter((user) => {
-    return !anonUserFromSignList.includes(user.user_id_followed);
+  const signUserList = await userFollowUserModel.findAll({
+    where: {
+      user_id_follower: userIdFollower,
+      is_anonymous: false
+    },
+    raw: true
   });
 
-  if (signUserList.length + anonUserWithoutSignUser.length <= 7) {
+  if (signUserList.length <= 7) {
     isBlurredPost = true;
   }
 

--- a/databases/functions/userFollowUser/check-is-blurred-post.js
+++ b/databases/functions/userFollowUser/check-is-blurred-post.js
@@ -1,0 +1,45 @@
+const findAnonymousUserId = require('../users/find-anonymous-user-id');
+
+/**
+ *
+ * @param {Model} userFollowUserModel
+ * @param {RegisterBodyData.Users} users
+ */
+module.exports = async (userFollowUserModel, userModel, userIdFollower, _transaction = null) => {
+  let isBlurredPost = false;
+
+  let [signUserList, anonUserList] = await Promise.all([
+    userFollowUserModel.findAll({
+      where: {
+        user_id_follower: userIdFollower,
+        is_anonymous: false
+      },
+      raw: true
+    }),
+    userFollowUserModel.findAll({
+      where: {
+        user_id_follower: userIdFollower,
+        is_anonymous: true
+      },
+      raw: true
+    })
+  ]);
+
+  let anonUserFromSignList = [];
+  await Promise.all(
+    signUserList.map(async (user) => {
+      let anonUserFromSign = await findAnonymousUserId(userModel, user.user_id_followed);
+      anonUserFromSignList.push(anonUserFromSign.user_id);
+    })
+  );
+
+  let anonUserWithoutSignUser = anonUserList.filter((user) => {
+    return !anonUserFromSignList.includes(user.user_id_followed);
+  });
+
+  if (signUserList.length + anonUserWithoutSignUser.length <= 7) {
+    isBlurredPost = true;
+  }
+
+  return isBlurredPost;
+};

--- a/databases/functions/userFollowUser/check-is-blurred-post.js
+++ b/databases/functions/userFollowUser/check-is-blurred-post.js
@@ -3,7 +3,7 @@
  * @param {Model} userFollowUserModel
  * @param {RegisterBodyData.Users} users
  */
-module.exports = async (userFollowUserModel, _userModel, userIdFollower, _transaction = null) => {
+module.exports = async (userFollowUserModel, userIdFollower, _transaction = null) => {
   let isBlurredPost = false;
 
   const signUserList = await userFollowUserModel.findAll({

--- a/databases/functions/userFollowUser/index.js
+++ b/databases/functions/userFollowUser/index.js
@@ -1,6 +1,7 @@
 const UserFollowUserFunction = {
   registerAddFollowUser: require('./user-follow-add'),
   checkIsUserFollowing: require('./check-is-user-following'),
+  checkIsBlurredPost: require('./check-is-blurred-post'),
   checkTargetUserFollowStatus: require('./check-target-user-follow-status'),
   checkTargetUserFollowStatusBatch: require('./check-target-user-follow-status-batch'),
   userBlock: require('./user-block'),

--- a/utils/post.js
+++ b/utils/post.js
@@ -156,7 +156,7 @@ const modifyAnonymousAndBlockPost = async (
   return feedWithAnonymous;
 };
 
-const modifyAnonimityPost = (item) => {
+const modifyAnonimityPost = async (item, isBlurredPost = true) => {
   const newItem = {...item};
 
   if (newItem.anonimity) {
@@ -164,6 +164,7 @@ const modifyAnonimityPost = (item) => {
     newItem.to = [];
     newItem.origin = null;
     newItem.object = '';
+    newItem.isBlurredPost = isBlurredPost;
   }
 
   return newItem;


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

- New Feature: Introduced a new feature that blurs the posts for users who are followed by 7 or fewer people, enhancing user privacy.
- Update: Modified the `modifyAnonimityPost` function to include an additional parameter `isBlurredPost`, which determines whether a post should be blurred or not.
- Update: The follow and unfollow API endpoints now return an additional field `isBlurredPost` in their success response, providing more context about the user's post visibility status.
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->