### PR TITLE
fix: reply message reply_data params to accomodate deleted message

### DIFF
--- a/utils/chat.js
+++ b/utils/chat.js
@@ -22,9 +22,12 @@ const generateReplyDataFromMessage = (message, userData, isAnonimous = true) => 
       id: message.user_id,
       name: isAnonimous ? anonymousName : userData.username,
       image: isAnonimous ? '' : userData.profile_pic_path,
-      username: isAnonimous ? anonymousName : userData.username
+      username: isAnonimous ? anonymousName : userData.username,
+      anon_user_info_emoji_name: userData?.anon_user_info_emoji_name,
+      anon_user_info_emoji_code: userData?.anon_user_info_emoji_code,
+      anon_user_info_color_name: userData?.anon_user_info_color_name,
+      anon_user_info_color_code: userData?.anon_user_info_color_code
     },
-    message: message.text,
     message_type: message.message_type || MESSAGE_TYPE.REGULAR
   };
 
@@ -36,8 +39,13 @@ const generateReplyDataFromMessage = (message, userData, isAnonimous = true) => 
     };
   }
 
+  const {id, type, created_at, updated_at} = message || {};
+
   return {
-    ...message,
+    id,
+    type,
+    created_at,
+    updated_at,
     ...baseReplyData
   };
 };
@@ -73,6 +81,7 @@ const processReplyMessage = async ({
     );
 
     baseMessage.reply_data = replyData;
+    baseMessage.quoted_message_id = replyMessageId;
 
     return baseMessage;
   }


### PR DESCRIPTION
This commit inlcudes:
1. Adjust reply_data params so that not including original message and attachments. Preventing deleted message to be expoesd
2. Simplify reply_data params to include only essentials params
3. Add quoted_message_id so getstream can process quoted message content automatically
<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

---
- Refactor: Enhanced the `generateReplyDataFromMessage` function in `utils/chat.js`. The update improves data structure for better handling and processing of chat messages.
- New Feature: Added `quoted_message_id` property to the `baseMessage` object in the `processReplyMessage` function. This feature allows tracking and referencing of quoted messages in chat replies, enhancing user interaction and conversation flow.
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->