### PR TITLE
fix: ping-3466 add params user populate

### DIFF
--- a/__tests__/api/users/populate.test.js
+++ b/__tests__/api/users/populate.test.js
@@ -29,4 +29,12 @@ describe('POST /users/populate?limit=50&offset=50', () => {
     expect(response.status).toBe(200);
     expect(response.body.data.length).toBe(10);
   });
+
+  test('Should return 200 OK with rest of the data if limit and offset is seta and filter by allow anon dm field', async () => {
+    const response = await supertest(app)
+      .get('/users/populate?limit=50&offset=50&allow_anon_dm=true')
+      .set('Authorization', 'Bearer token');
+    expect(response.status).toBe(200);
+    expect(response.body.data.length).toBe(10);
+  });
 });

--- a/joi-validations/users.validations.js
+++ b/joi-validations/users.validations.js
@@ -1,10 +1,15 @@
-const {object, string} = require('./general.validations');
+const {object, string, boolean} = require('./general.validations');
 
 const UserValidation = {
   authenticateWeb: {
     body: object({
       exchangeToken: string.required()
     })
+  },
+  populateUsers: {
+    query: {
+      allow_anon_dm: boolean
+    }
   }
 };
 

--- a/joi-validations/users.validations.js
+++ b/joi-validations/users.validations.js
@@ -1,4 +1,4 @@
-const {object, string, boolean} = require('./general.validations');
+const {object, string, boolean, number} = require('./general.validations');
 
 const UserValidation = {
   authenticateWeb: {
@@ -8,7 +8,9 @@ const UserValidation = {
   },
   populateUsers: {
     query: {
-      allow_anon_dm: boolean
+      allow_anon_dm: boolean,
+      limit: number,
+      offset: number
     }
   }
 };

--- a/routes/users.js
+++ b/routes/users.js
@@ -51,7 +51,7 @@ router.post('/blockuser', auth.isAuth, usersHandler.blockUser);
 router.post('/block-domain', auth.isAuth, usersHandler.blockDomain);
 router.post('/check-block-status', auth.isAuth, usersHandler.userBlockStatus);
 router.post('/unblock', auth.isAuth, usersHandler.userUnblock);
-router.get('/populate', auth.isAuth, usersHandler.populate);
+router.get('/populate', auth.isAuth, validate(UserValidation.populateUsers), usersHandler.populate);
 router.post('/block-post-anonymous', auth.isAuth, usersHandler.blockPostAnonymous);
 router.post('/delete', auth.isAuth, usersHandler.deleteUser);
 router.post('/rename/:userId', auth.isAuth, usersHandler.renameUser);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

---
- New Feature: Added a new query parameter `allow_anon_dm` to the `/users/populate` endpoint. This allows users to filter results based on whether anonymous direct messages are allowed.
- Refactor: Updated the SQL query in `populateUser.js` to include filtering based on the `allow_anon_dm` parameter.
- Test: Added a new test case for the `POST /users/populate` endpoint to verify the correct behavior when `limit`, `offset`, and `allow_anon_dm` parameters are set.
- Chore: Enhanced input validation for the `/users/populate` endpoint by adding a middleware function to validate the `allow_anon_dm` parameter.

<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->