### PR TITLE
fix: update better channel member if getting channel detail

### DIFF
--- a/controllers/chat/getChannelDetail.js
+++ b/controllers/chat/getChannelDetail.js
@@ -37,7 +37,7 @@ const getChannelDetail = async (req, res) => {
   }
 
   const {betterChannelMember, betterChannelMemberObject} =
-    await BetterSocialCore.chat.updateBetterChannelMembers(channel, createdChannel);
+    await BetterSocialCore.chat.updateBetterChannelMembers(channel, createdChannel, true);
 
   return ResponseSuccess(res, 'Success', 200, {
     better_channel_members: betterChannelMember,


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

- Refactor: Updated the `getChannelDetail` function in the chat controller. The function now includes an additional parameter when calling `updateBetterChannelMembers`, enhancing its functionality. This change may affect how channel details are retrieved and displayed to the user. Please refer to the application's documentation for further details on this update.
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->