### PR TITLE
feat: ping-3763 leave group member

### DIFF
--- a/controllers/chat/group/leaveGroupMember.js
+++ b/controllers/chat/group/leaveGroupMember.js
@@ -1,0 +1,34 @@
+const BetterSocialCore = require('../../../services/bettersocial');
+const {ResponseSuccess} = require('../../../utils/Responses');
+const ErrorResponse = require('../../../utils/response/ErrorResponse');
+const Getstream = require('../../../vendor/getstream');
+
+const leaveGroupMember = async (req, res) => {
+  const {userId} = req;
+  const {channelId} = req.body;
+
+  try {
+    const response = await Getstream.chat.removeGroupMember(channelId, userId);
+    const {channel, channelApiResponse} = response.data || {};
+
+    let channelResponse;
+    try {
+      const {newChannelName, betterChannelMember, betterChannelMemberObject, updatedChannel} =
+        await BetterSocialCore.chat.updateBetterChannelMembers(channel, channelApiResponse, true);
+
+      channelResponse = updatedChannel;
+
+      channelApiResponse.channel.name = newChannelName;
+      channelApiResponse.channel.better_channel_member = betterChannelMember;
+      channelApiResponse.channel.better_channel_member_object = betterChannelMemberObject;
+    } catch (e) {
+      console.log(e);
+    }
+
+    return ResponseSuccess(res, response?.message, 200, channelResponse);
+  } catch (e) {
+    return ErrorResponse.e500(res, e.message);
+  }
+};
+
+module.exports = leaveGroupMember;

--- a/controllers/chat/index.js
+++ b/controllers/chat/index.js
@@ -16,6 +16,7 @@ const sendAnonymousMessage = require('./sendAnonymousMessage');
 const setSignedChannelAsRead = require('./setSignedChannelAsRead');
 const deleteMessage = require('./deleteMessage');
 const newChatAnonymous = require('./newChatAnonymous');
+const leaveGroupMember = require('./group/leaveGroupMember');
 
 module.exports = {
   changeChannelDetail,
@@ -35,5 +36,6 @@ module.exports = {
   sendSignedMessage,
   setSignedChannelAsRead,
   deleteMessage,
-  newChatAnonymous
+  newChatAnonymous,
+  leaveGroupMember
 };

--- a/joi-validations/chat.validations.js
+++ b/joi-validations/chat.validations.js
@@ -162,6 +162,12 @@ const ChatValidation = {
       channelId: string.required(),
       targetUserId: uuid.required()
     }
+  },
+
+  leaveGroupMember: {
+    body: {
+      channelId: string.required()
+    }
   }
 };
 

--- a/routes/chat.js
+++ b/routes/chat.js
@@ -25,7 +25,8 @@ const {
   initChatFromProfileAsAnonymousV2,
   initChatFromProfileAsSignedV2,
   sendAnonymousMessage,
-  newChatAnonymous
+  newChatAnonymous,
+  leaveGroupMember
 } = require('../controllers/chat');
 const {ChatValidation} = require('../joi-validations/chat.validations');
 const {validate} = require('../middlewares/joi-validation/validate');
@@ -133,6 +134,13 @@ router.post(
   validate(ChatValidation.removeGroupMember),
   auth.isAuthV2,
   removeGroupMember
+);
+
+router.post(
+  '/group/leave',
+  validate(ChatValidation.leaveGroupMember),
+  auth.isAuthV2,
+  leaveGroupMember
 );
 
 module.exports = router;


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

- New Feature: Introduced the ability for users to leave a group chat. This update includes a new endpoint `/group/leave` that handles the removal of a user from a chat channel. The feature ensures seamless interaction with external services like Getstream and BetterSocialCore for updating channel members.
- Enhancement: Added robust error handling to manage potential failures during the process, improving the reliability of the chat functionality.
- New Feature: Implemented input validation for the `leaveGroupMember` function to ensure data integrity when processing requests.
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->