### PR TITLE
feat: ping-3666 prevent chat to blocked user

### DIFF
--- a/controllers/chat/sendAnonymousMessage.js
+++ b/controllers/chat/sendAnonymousMessage.js
@@ -3,6 +3,8 @@ const {StreamChat} = require('stream-chat');
 const {responseError, responseSuccess} = require('../../utils/Responses');
 const {MESSAGE_TYPE} = require('../../helpers/constants');
 const {determineMessageType, processReplyMessage} = require('../../utils/chat');
+const UsersFunction = require('../../databases/functions/users');
+const {User, UserBlockedUser} = require('../../databases/models');
 
 const v = new Validator();
 const sendAnonymousMessage = async (req, res) => {
@@ -64,6 +66,23 @@ const sendAnonymousMessage = async (req, res) => {
     }
     if (createdChannel?.channel?.is_channel_blocked)
       return res.status(403).json(responseError('Channel is blocked'));
+
+    // Prevent if user try to chat with blocked user
+    let channelType = createdChannel?.channel?.channel_type;
+    if (channelType === 4 || channelType === 0) {
+      let signUser = await UsersFunction.findSignedUserId(User, req.userId);
+      const blockedIds = await UsersFunction.getBlockedAndBlockerUserId(UserBlockedUser, signUser);
+      let better_channel_member = createdChannel?.channel?.better_channel_member;
+      if (blockedIds.length > 0) {
+        for (const member of better_channel_member) {
+          if (member.user_id !== req.userId && blockedIds.includes(member.user_id)) {
+            return res
+              .status(403)
+              .json(responseError('This user does not want to receive messages'));
+          }
+        }
+      }
+    }
 
     const currentMessageType = determineMessageType(messageType, attachments);
     let baseMessage = {

--- a/controllers/chat/sendAnonymousMessage.js
+++ b/controllers/chat/sendAnonymousMessage.js
@@ -73,14 +73,12 @@ const sendAnonymousMessage = async (req, res) => {
       let signUser = await UsersFunction.findSignedUserId(User, req.userId);
       const blockedIds = await UsersFunction.getBlockedAndBlockerUserId(UserBlockedUser, signUser);
       let better_channel_member = createdChannel?.channel?.better_channel_member;
-      if (blockedIds.length > 0) {
-        for (const member of better_channel_member) {
-          if (member.user_id !== req.userId && blockedIds.includes(member.user_id)) {
-            return res
-              .status(403)
-              .json(responseError('This user does not want to receive messages'));
-          }
-        }
+      const blockedIdsSet = new Set(blockedIds);
+      const isBlocked = better_channel_member.some(
+        (member) => member.user_id !== req.userId && blockedIdsSet.has(member.user_id)
+      );
+      if (isBlocked) {
+        return res.status(403).json(responseError('This user does not want to receive messages'));
       }
     }
 

--- a/controllers/chat/sendSignedMessage.js
+++ b/controllers/chat/sendSignedMessage.js
@@ -94,15 +94,22 @@ const sendSignedMesage = async (req, res) => {
         req.userId
       );
       let better_channel_member = createdChannel?.channel?.better_channel_member;
-      if (blockedIds.length > 0) {
-        for (const member of better_channel_member) {
-          if (member.user_id !== req.userId && blockedIds.includes(member.user_id)) {
-            return res
-              .status(403)
-              .json(responseError('This user does not want to receive messages'));
-          }
-        }
+      const blockedIdsSet = new Set(blockedIds);
+      const isBlocked = better_channel_member.some(
+        (member) => member.user_id !== req.userId && blockedIdsSet.has(member.user_id)
+      );
+      if (isBlocked) {
+        return res.status(403).json(responseError('This user does not want to receive messages'));
       }
+      // if (blockedIds.length > 0) {
+      //   for (const member of better_channel_member) {
+      //     if (member.user_id !== req.userId && blockedIds.includes(member.user_id)) {
+      //       return res
+      //         .status(403)
+      //         .json(responseError('This user does not want to receive messages'));
+      //     }
+      //   }
+      // }
     }
 
     const currentMessageType = determineMessageType(messageType, attachments);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

- Bug Fix: Enhanced user privacy by preventing users from sending messages to blocked contacts. This applies to both anonymous and signed messages across all channel types. If a user attempts to send a message to a blocked contact, the action will be blocked and an error message will be returned.
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->