### PR TITLE
fix: fix skippush add group members

### DIFF
--- a/controllers/chat/group/changeChannelDetail.js
+++ b/controllers/chat/group/changeChannelDetail.js
@@ -38,20 +38,25 @@ const changeChannelDetail = async (req, res) => {
       const textTargetUser = `${ownUser.username} changed the group name to "${channel_name}"`;
       const textDefaultUser = `${ownUser.username} changed the group name to "${channel_name}"`;
 
-      await channel.sendMessage({
-        text: textDefaultUser,
-        own_text: textOwnUser,
-        other_text: textTargetUser,
-        better_type: 'change_channel_detail',
-        type: 'system',
-        user_id: userId,
-        only_to_user_show: userId,
-        disable_to_user: false,
-        is_from_prepopulated: true,
-        system_user: userId,
-        isSystem: true,
-        members: members
-      });
+      await channel.sendMessage(
+        {
+          text: textDefaultUser,
+          own_text: textOwnUser,
+          other_text: textTargetUser,
+          better_type: 'change_channel_detail',
+          type: 'system',
+          user_id: userId,
+          only_to_user_show: userId,
+          disable_to_user: false,
+          is_from_prepopulated: true,
+          system_user: userId,
+          isSystem: true,
+          members: members
+        },
+        {
+          skip_push: true
+        }
+      );
     }
 
     if (channel_image) {
@@ -59,17 +64,22 @@ const changeChannelDetail = async (req, res) => {
       const textTargetUser = `${ownUser.username} changed the group image`;
       const textOtherUser = `${ownUser.username} changed the group image`;
 
-      await channel.sendMessage({
-        text: textOtherUser,
-        own_text: textOwnUser,
-        other_text: textTargetUser,
-        better_type: 'change_channel_detail',
-        type: 'system',
-        user_id: userId,
-        system_user: userId,
-        isSystem: true,
-        members: members
-      });
+      await channel.sendMessage(
+        {
+          text: textOtherUser,
+          own_text: textOwnUser,
+          other_text: textTargetUser,
+          better_type: 'change_channel_detail',
+          type: 'system',
+          user_id: userId,
+          system_user: userId,
+          isSystem: true,
+          members: members
+        },
+        {
+          skip_push: true
+        }
+      );
     }
 
     const response = await channel.updatePartial({

--- a/controllers/chat/group/changeChannelDetail.js
+++ b/controllers/chat/group/changeChannelDetail.js
@@ -62,7 +62,6 @@ const changeChannelDetail = async (req, res) => {
       );
 
       const other_members = all_members.filter((m) => m !== userId);
-      await BetterSocialCore.fcmToken.sendGroupChatNotification(userId, textOwnUser);
       await Promise.all(
         other_members.map(async (m) => {
           await BetterSocialCore.fcmToken.sendGroupChatNotification(m, textDefaultUser);

--- a/controllers/chat/group/changeChannelDetail.js
+++ b/controllers/chat/group/changeChannelDetail.js
@@ -4,7 +4,6 @@ const ErrorResponse = require('../../../utils/response/ErrorResponse');
 const {ResponseSuccess} = require('../../../utils/Responses');
 const UsersFunction = require('../../../databases/functions/users');
 const {User} = require('../../../databases/models');
-const BetterSocialCore = require('../../../services/bettersocial');
 
 /**
  *
@@ -25,8 +24,6 @@ const changeChannelDetail = async (req, res) => {
   });
 
   if (queriedChannel?.length < 1) return ErrorResponse.e404(res, 'Group not found');
-
-  let all_members = queriedChannel[0].data.better_channel_member.map((member) => member.user.id);
 
   const channel = await client.channel(CHANNEL_TYPE_STRING.GROUP, channel_id);
   const updateData = {};
@@ -60,13 +57,6 @@ const changeChannelDetail = async (req, res) => {
           skip_push: true
         }
       );
-
-      const other_members = all_members.filter((m) => m !== userId);
-      await Promise.all(
-        other_members.map(async (m) => {
-          await BetterSocialCore.fcmToken.sendGroupChatNotification(m, textDefaultUser);
-        })
-      );
     }
 
     if (channel_image) {
@@ -89,14 +79,6 @@ const changeChannelDetail = async (req, res) => {
         {
           skip_push: true
         }
-      );
-
-      const other_members = all_members.filter((m) => m !== userId);
-      await BetterSocialCore.fcmToken.sendGroupChatNotification(userId, textOwnUser);
-      await Promise.all(
-        other_members.map(async (m) => {
-          await BetterSocialCore.fcmToken.sendGroupChatNotification(m, textDefaultUser);
-        })
       );
     }
 

--- a/controllers/chat/group/groupAddMembers.js
+++ b/controllers/chat/group/groupAddMembers.js
@@ -45,8 +45,8 @@ const groupAddMembers = async (req, res) => {
 
   const channel = await client.queryChannels({
     id: channel_id,
-    type: CHANNEL_TYPE_STRING.GROUP /* ,
-    members: {$in: [userId]} */
+    type: CHANNEL_TYPE_STRING.GROUP,
+    members: {$in: [userId]}
   });
   if (channel?.length < 1) {
     return ErrorResponse.e404(res, 'Group not found');
@@ -91,11 +91,7 @@ const groupAddMembers = async (req, res) => {
       );
 
       const other_members = all_members.filter((m) => m !== member && m !== userId);
-      try {
-        await BetterSocialCore.fcmToken.sendGroupChatNotification(userId, textOwnUser);
-      } catch (error) {
-        console.error('Failed to send group chat notification to user', error);
-      }
+      await BetterSocialCore.fcmToken.sendGroupChatNotification(userId, textOwnUser);
       await BetterSocialCore.fcmToken.sendGroupChatNotification(member, textTargetUser);
       await Promise.all(
         other_members.map(async (m) => {

--- a/controllers/chat/group/groupAddMembers.js
+++ b/controllers/chat/group/groupAddMembers.js
@@ -61,29 +61,34 @@ const groupAddMembers = async (req, res) => {
   try {
     const responseChannel = await channelToAdd?.addMembers(filteredMembersObject);
 
-    filteredMembersId.map(async (member) => {
-      const targetUserModel = await UsersFunction.findUserById(User, member);
+    filteredMembersId.map(
+      async (member) => {
+        const targetUserModel = await UsersFunction.findUserById(User, member);
 
-      const textOwnUser = `You added ${targetUserModel.username} to this group`;
-      const textTargetUser = `${ownUser.username} added you to this group`;
-      const textDefaultUser = `${ownUser.username} added ${targetUserModel.username} to this group`;
+        const textOwnUser = `You added ${targetUserModel.username} to this group`;
+        const textTargetUser = `${ownUser.username} added you to this group`;
+        const textDefaultUser = `${ownUser.username} added ${targetUserModel.username} to this group`;
 
-      await channelToAdd.sendMessage({
-        text: textDefaultUser,
-        own_text: textOwnUser,
-        other_text: textTargetUser,
-        other_system_user: member,
-        better_type: 'add_member_to_group',
-        type: 'system',
-        user_id: userId,
-        only_to_user_show: userId,
-        disable_to_user: false,
-        is_from_prepopulated: true,
-        system_user: userId,
-        isSystem: true,
-        members: [member]
-      });
-    });
+        await channelToAdd.sendMessage({
+          text: textDefaultUser,
+          own_text: textOwnUser,
+          other_text: textTargetUser,
+          other_system_user: member,
+          better_type: 'add_member_to_group',
+          type: 'system',
+          user_id: userId,
+          only_to_user_show: userId,
+          disable_to_user: false,
+          is_from_prepopulated: true,
+          system_user: userId,
+          isSystem: true,
+          members: [member]
+        });
+      },
+      {
+        skip_push: true
+      }
+    );
 
     try {
       const {betterChannelMember, betterChannelMemberObject, newChannelName, updatedChannel} =

--- a/controllers/chat/group/groupAddMembers.js
+++ b/controllers/chat/group/groupAddMembers.js
@@ -52,8 +52,6 @@ const groupAddMembers = async (req, res) => {
     return ErrorResponse.e404(res, 'Group not found');
   }
 
-  let all_members = channel[0].data.better_channel_member.map((member) => member.user.id);
-
   const channelMembers = [userId, ...filteredMembersId];
   const channelToAdd = await client.channel(CHANNEL_TYPE_STRING.GROUP, channel_id, {
     members: channelMembers
@@ -90,14 +88,7 @@ const groupAddMembers = async (req, res) => {
         }
       );
 
-      const other_members = all_members.filter((m) => m !== member && m !== userId);
-      await BetterSocialCore.fcmToken.sendGroupChatNotification(userId, textOwnUser);
       await BetterSocialCore.fcmToken.sendGroupChatNotification(member, textTargetUser);
-      await Promise.all(
-        other_members.map(async (m) => {
-          await BetterSocialCore.fcmToken.sendGroupChatNotification(m, textDefaultUser);
-        })
-      );
     });
 
     try {

--- a/controllers/chat/group/leaveGroupMember.js
+++ b/controllers/chat/group/leaveGroupMember.js
@@ -56,14 +56,6 @@ const leaveGroupMember = async (req, res) => {
       }
     );
 
-    const other_members = all_members.filter((m) => m !== userId);
-    await BetterSocialCore.fcmToken.sendGroupChatNotification(userId, textOwnUser);
-    await Promise.all(
-      other_members.map(async (m) => {
-        await BetterSocialCore.fcmToken.sendGroupChatNotification(m, textDefaultUser);
-      })
-    );
-
     channelResponse = updatedChannel;
 
     channelApiResponse.channel.name = newChannelName;

--- a/controllers/chat/group/leaveGroupMember.js
+++ b/controllers/chat/group/leaveGroupMember.js
@@ -34,20 +34,25 @@ const leaveGroupMember = async (req, res) => {
       const textDefaultUser = `${ownUser.username} left this group`;
       const members = betterChannelMember.map((member) => member.user_id);
 
-      await currentChannel.sendMessage({
-        text: textDefaultUser,
-        own_text: textOwnUser,
-        other_text: textTargetUser,
-        better_type: 'leave_group',
-        type: 'system',
-        user_id: userId,
-        only_to_user_show: userId,
-        disable_to_user: false,
-        is_from_prepopulated: true,
-        system_user: userId,
-        isSystem: true,
-        members: members
-      });
+      await currentChannel.sendMessage(
+        {
+          text: textDefaultUser,
+          own_text: textOwnUser,
+          other_text: textTargetUser,
+          better_type: 'leave_group',
+          type: 'system',
+          user_id: userId,
+          only_to_user_show: userId,
+          disable_to_user: false,
+          is_from_prepopulated: true,
+          system_user: userId,
+          isSystem: true,
+          members: members
+        },
+        {
+          skip_push: true
+        }
+      );
 
       channelResponse = updatedChannel;
 

--- a/controllers/chat/group/removeGroupMember.js
+++ b/controllers/chat/group/removeGroupMember.js
@@ -35,21 +35,26 @@ const removeGroupMember = async (req, res) => {
       const textDefaultUser = `${ownUser.username} removed ${targetUserModel.username} from this group`;
       const members = betterChannelMember.map((member) => member.user_id);
 
-      await currentChannel.sendMessage({
-        text: textDefaultUser,
-        own_text: textOwnUser,
-        other_text: textTargetUser,
-        other_system_user: userId,
-        better_type: 'remove_member_from_group',
-        type: 'system',
-        user_id: userId,
-        only_to_user_show: userId,
-        disable_to_user: false,
-        is_from_prepopulated: true,
-        system_user: userId,
-        isSystem: true,
-        members: members
-      });
+      await currentChannel.sendMessage(
+        {
+          text: textDefaultUser,
+          own_text: textOwnUser,
+          other_text: textTargetUser,
+          other_system_user: userId,
+          better_type: 'remove_member_from_group',
+          type: 'system',
+          user_id: userId,
+          only_to_user_show: userId,
+          disable_to_user: false,
+          is_from_prepopulated: true,
+          system_user: userId,
+          isSystem: true,
+          members: members
+        },
+        {
+          skip_push: true
+        }
+      );
 
       channelResponse = updatedChannel;
 

--- a/controllers/chat/group/removeGroupMember.js
+++ b/controllers/chat/group/removeGroupMember.js
@@ -59,18 +59,9 @@ const removeGroupMember = async (req, res) => {
         }
       );
 
-      const other_members = all_members.filter(
-        (m) => m !== targetUserModel.user_id && m !== userId
-      );
-      await BetterSocialCore.fcmToken.sendGroupChatNotification(userId, textOwnUser);
       await BetterSocialCore.fcmToken.sendGroupChatNotification(
         targetUserModel.user_id,
         textTargetUser
-      );
-      await Promise.all(
-        other_members.map(async (m) => {
-          await BetterSocialCore.fcmToken.sendGroupChatNotification(m, textDefaultUser);
-        })
       );
 
       channelResponse = updatedChannel;

--- a/services/bettersocial/fcmToken/sendGroupChatNotification.js
+++ b/services/bettersocial/fcmToken/sendGroupChatNotification.js
@@ -1,0 +1,26 @@
+const {messaging} = require('firebase-admin');
+const FcmTokenFunction = require('../../../databases/functions/fcmToken');
+const {FcmToken} = require('../../../databases/models');
+
+const sendGroupChatNotification = async (userTargetId, message) => {
+  const userTargetToken = await FcmTokenFunction.findTokenByUserId(FcmToken, userTargetId);
+
+  const payload = {
+    notification: {
+      title: message,
+      body: message
+    },
+    data: {}
+  };
+  if (userTargetToken) {
+    try {
+      messaging()
+        .sendToDevice(userTargetToken?.token, payload)
+        .then(() => {});
+    } catch (error) {
+      console.log('error send group chat notifications', error);
+    }
+  }
+};
+
+module.exports = sendGroupChatNotification;

--- a/services/bettersocial/index.js
+++ b/services/bettersocial/index.js
@@ -33,7 +33,8 @@ const BetterSocialCore = {
     sendReplyCommentNotification: require('./fcmToken/sendReplyCommentNotification'),
     sendMultiDeviceNotification: require('./fcmToken/sendMultiDeviceNotification'),
     sendMultiDeviceCommentNotification: require('./fcmToken/sendMultiDeviceCommentNotification'),
-    sendMultiDeviceReplyCommentNotification: require('./fcmToken/sendMultiDeviceReplyCommentNotification')
+    sendMultiDeviceReplyCommentNotification: require('./fcmToken/sendMultiDeviceReplyCommentNotification'),
+    sendGroupChatNotification: require('./fcmToken/sendGroupChatNotification')
   },
   post: {
     blockAnonymousPost: require('./post/blockAnonymousPost'),


### PR DESCRIPTION





<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

- New Feature: Added `sendGroupChatNotification` function to send group chat notifications using Firebase Cloud Messaging.
- Refactor: Updated message sending logic in `changeChannelDetail`, `leaveGroupMember`, `removeGroupMember`, and `groupAddMembers` functions to include an option to skip push notifications.
- Refactor: Enhanced notification handling for group members in `groupAddMembers`.
- Refactor: Improved error handling for sending notifications in `groupAddMembers`.
- Refactor: Modified member handling and notification sending in `leaveGroupMember` and `removeGroupMember`.
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->