### PR TITLE
fix: move msg before remove user

### DIFF
--- a/controllers/chat/group/leaveGroupMember.js
+++ b/controllers/chat/group/leaveGroupMember.js
@@ -23,14 +23,8 @@ const leaveGroupMember = async (req, res) => {
       type: CHANNEL_TYPE_STRING.GROUP,
       id: channelId
     });
-    console.log(':::queriedChannel', queriedChannel);
+
     let all_members = queriedChannel[0].data.better_channel_member.map((member) => member.user.id);
-
-    const response = await Getstream.chat.removeGroupMember(channelId, userId);
-    const {channel, channelApiResponse} = response.data || {};
-
-    const {newChannelName, betterChannelMember, betterChannelMemberObject, updatedChannel} =
-      await BetterSocialCore.chat.updateBetterChannelMembers(channel, channelApiResponse, true);
 
     const textOwnUser = `You left this group`;
     const textTargetUser = `${ownUser.username} left this group`;
@@ -55,6 +49,12 @@ const leaveGroupMember = async (req, res) => {
         skip_push: true
       }
     );
+
+    const response = await Getstream.chat.removeGroupMember(channelId, userId);
+    const {channel, channelApiResponse} = response.data || {};
+
+    const {newChannelName, betterChannelMember, betterChannelMemberObject, updatedChannel} =
+      await BetterSocialCore.chat.updateBetterChannelMembers(channel, channelApiResponse, true);
 
     channelResponse = updatedChannel;
 

--- a/controllers/chat/group/removeGroupMember.js
+++ b/controllers/chat/group/removeGroupMember.js
@@ -26,6 +26,31 @@ const removeGroupMember = async (req, res) => {
 
     let all_members = queriedChannel[0].data.better_channel_member.map((member) => member.user.id);
 
+    const textOwnUser = `You removed ${targetUserModel.username} from this group`;
+    const textTargetUser = `${ownUser.username} removed you from this group`;
+    const textDefaultUser = `${ownUser.username} removed ${targetUserModel.username} from this group`;
+
+    await currentChannel.sendMessage(
+      {
+        text: textDefaultUser,
+        own_text: textOwnUser,
+        other_text: textTargetUser,
+        other_system_user: targetUserModel.user_id,
+        better_type: 'remove_member_from_group',
+        type: 'system',
+        user_id: userId,
+        only_to_user_show: userId,
+        disable_to_user: false,
+        is_from_prepopulated: true,
+        system_user: userId,
+        isSystem: true,
+        members: all_members
+      },
+      {
+        skip_push: true
+      }
+    );
+
     const response = await Getstream.chat.removeGroupMember(channelId, userId, targetUserId);
     const {channel, channelApiResponse} = response.data || {};
 
@@ -33,31 +58,6 @@ const removeGroupMember = async (req, res) => {
     try {
       const {newChannelName, betterChannelMember, betterChannelMemberObject, updatedChannel} =
         await BetterSocialCore.chat.updateBetterChannelMembers(channel, channelApiResponse, true);
-
-      const textOwnUser = `You removed ${targetUserModel.username} from this group`;
-      const textTargetUser = `${ownUser.username} removed you from this group`;
-      const textDefaultUser = `${ownUser.username} removed ${targetUserModel.username} from this group`;
-
-      await currentChannel.sendMessage(
-        {
-          text: textDefaultUser,
-          own_text: textOwnUser,
-          other_text: textTargetUser,
-          other_system_user: targetUserModel.user_id,
-          better_type: 'remove_member_from_group',
-          type: 'system',
-          user_id: userId,
-          only_to_user_show: userId,
-          disable_to_user: false,
-          is_from_prepopulated: true,
-          system_user: userId,
-          isSystem: true,
-          members: all_members
-        },
-        {
-          skip_push: true
-        }
-      );
 
       await BetterSocialCore.fcmToken.sendGroupChatNotification(
         targetUserModel.user_id,


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

---
- Refactor: Updated the process of removing a group member in `leaveGroupMember.js` and `removeGroupMember.js`. The changes ensure that user removal is handled more efficiently and notifications are sent prior to the actual removal. This enhances the user experience by providing timely updates about group membership changes.
---
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->