### PR TITLE
fix: change karma score to 45 and load more at other popular users

### DIFF
--- a/controllers/whoToFollow/whoToFollowV2.js
+++ b/controllers/whoToFollow/whoToFollowV2.js
@@ -58,8 +58,8 @@ module.exports = async (req, res) => {
                             AND a.user_id != :admin_user_id
                             AND b.topic_id = :topic_id
                           ORDER BY 
-                            a.last_active_at DESC,
-                            CASE WHEN a.profile_pic_path != '%default-profile-picture%' THEN 0 ELSE 1 END,
+                            CASE WHEN a.last_active_at > now() - interval '7' day THEN 0 ELSE 1 END,
+                            CASE WHEN a.profile_pic_path NOT LIKE '%default-profile-picture%' THEN 0 ELSE 1 END,
                             a.followers_count DESC
                           LIMIT :limit OFFSET :offset`;
 
@@ -148,8 +148,8 @@ module.exports = async (req, res) => {
                                 AND a.karma_score > 45
                                 AND b.location_id = :location_id
                               ORDER BY 
-                                a.last_active_at DESC,
-                                CASE WHEN a.profile_pic_path != '%default-profile-picture%' THEN 0 ELSE 1 END,
+                                CASE WHEN a.last_active_at > now() - interval '7' day THEN 0 ELSE 1 END,
+                                CASE WHEN a.profile_pic_path NOT LIKE '%default-profile-picture%' THEN 0 ELSE 1 END,
                                 a.followers_count DESC
                               LIMIT :limit OFFSET :offset`;
 
@@ -225,8 +225,8 @@ module.exports = async (req, res) => {
                             AND a.user_id NOT IN (:allUserIds)
                           GROUP BY a.user_id
                           ORDER BY 
-                            a.last_active_at DESC,
-                            CASE WHEN a.profile_pic_path != '%default-profile-picture%' THEN 0 ELSE 1 END,
+                            CASE WHEN a.last_active_at > now() - interval '7' day THEN 0 ELSE 1 END,
+                            CASE WHEN a.profile_pic_path NOT LIKE '%default-profile-picture%' THEN 0 ELSE 1 END,
                             a.followers_count DESC
                           LIMIT :limit OFFSET :offset`;
 

--- a/controllers/whoToFollow/whoToFollowV2.js
+++ b/controllers/whoToFollow/whoToFollowV2.js
@@ -54,7 +54,7 @@ module.exports = async (req, res) => {
                             a.is_anonymous = false
                             AND a.is_banned = false
                             AND a.blocked_by_admin = false
-                            AND a.karma_score > 30
+                            AND a.karma_score > 45
                             AND a.user_id != :admin_user_id
                             AND b.topic_id = :topic_id
                           ORDER BY 
@@ -145,7 +145,7 @@ module.exports = async (req, res) => {
                                 a.is_anonymous = false
                                 AND a.is_banned = false
                                 AND a.blocked_by_admin = false
-                                AND a.karma_score > 30
+                                AND a.karma_score > 45
                                 AND b.location_id = :location_id
                               ORDER BY 
                                 a.last_active_at DESC,
@@ -191,7 +191,7 @@ module.exports = async (req, res) => {
     //END LOCATIONS
 
     //OTHER USERS
-    if (page == 1 && topics) {
+    if (topics) {
       allUserIds.push(process.env.BETTER_ADMIN_ID);
       const otherTopicsQuery = `SELECT 
                             a.user_id,
@@ -220,7 +220,7 @@ module.exports = async (req, res) => {
                             a.is_anonymous = false
                             AND a.is_banned = false
                             AND a.blocked_by_admin = false
-                            AND a.karma_score > 30
+                            AND a.karma_score > 45
                             AND b.topic_id NOT IN (:topics)
                             AND a.user_id NOT IN (:allUserIds)
                           GROUP BY a.user_id
@@ -228,14 +228,15 @@ module.exports = async (req, res) => {
                             a.last_active_at DESC,
                             CASE WHEN a.profile_pic_path != '%default-profile-picture%' THEN 0 ELSE 1 END,
                             a.followers_count DESC
-                          LIMIT :limit`;
+                          LIMIT :limit OFFSET :offset`;
 
       const userOtherTopicFollowerQueryResult = await sequelize.query(otherTopicsQuery, {
         type: sequelize.QueryTypes.SELECT,
         replacements: {
           topics,
           allUserIds,
-          limit
+          limit,
+          offset
         }
       });
       const userOtherTopicFollower = userOtherTopicFollowerQueryResult;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

---
- **Refactor**: Updated the "Who to Follow" feature to improve user recommendations. The karma score threshold for suggested users has been increased from 30 to 45, ensuring higher quality suggestions.
- **New Feature**: Enhanced sorting criteria for user recommendations based on their last active time and presence of a profile picture, providing more relevant and engaging suggestions.
- **Bug Fix**: Removed an unnecessary condition related to page number that was causing inconsistencies in user recommendations.
- **New Feature**: Added pagination offsets to queries fetching user data based on topics and popular users, improving performance and usability of the "Who to Follow" feature.
---
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->