### PR TITLE
fix: update limit bug topics

### DIFF
--- a/controllers/topics/index.js
+++ b/controllers/topics/index.js
@@ -131,7 +131,7 @@ const getTopics = async (req, res) => {
                 "Topic"."topic_id"
             ORDER BY
                 "followersCount" DESC
-            LIMIT 5`,
+            LIMIT 50`,
       {
         type: QueryTypes.SELECT,
         replacements: {


### PR DESCRIPTION
menambahkan limit, karena saat ini yang di tampilkan di list search eg. carliton 7 topics hasil pencarian tetapi ketika di klik dan run endpoint ini cuman di limit 5 dan topic yg cari tersebut tidak termasuk