### PR TITLE
fix: ping-4002 add is_you and karma score at comment level 2

### DIFF
--- a/utils/custom.js
+++ b/utils/custom.js
@@ -101,7 +101,8 @@ const convertLocationFromModel = (locationModel, isTO = false) => {
 };
 
 const setChildCommentLv2 = (childCommentLv2 = [], karmaScores, mySignUserId, myAnonymousId) => {
-  const new_child_comment_lv2 = childCommentLv2?.map((child2) => {
+  let new_child_comment_lv2 = childCommentLv2;
+  return new_child_comment_lv2.map((child2) => {
     const child2_user = karmaScores.find((user) => user.user_id === child2.user_id);
     if (child2.data.anon_user_info_emoji_name) {
       return {
@@ -119,8 +120,6 @@ const setChildCommentLv2 = (childCommentLv2 = [], karmaScores, mySignUserId, myA
       karmaScores: roundingKarmaScore(child2_user?.karma_score || 0)
     };
   });
-
-  return new_child_comment_lv2;
 };
 
 const handleAnonymousData = async (

--- a/utils/custom.js
+++ b/utils/custom.js
@@ -100,8 +100,8 @@ const convertLocationFromModel = (locationModel, isTO = false) => {
   return '';
 };
 
-const setChildCommentLv2 = (childCommentLv2 = [], karmaScores, mySignUserId, myAnonymousId) => {
-  let new_child_comment_lv2 = childCommentLv2;
+const setChildCommentLv2 = (childCommentLv2, karmaScores, mySignUserId, myAnonymousId) => {
+  let new_child_comment_lv2 = childCommentLv2 || [];
   return new_child_comment_lv2.map((child2) => {
     const child2_user = karmaScores.find((user) => user.user_id === child2.user_id);
     if (child2.data.anon_user_info_emoji_name) {

--- a/utils/custom.js
+++ b/utils/custom.js
@@ -101,7 +101,7 @@ const convertLocationFromModel = (locationModel, isTO = false) => {
 };
 
 const setChildCommentLv2 = (childCommentLv2 = [], karmaScores, mySignUserId, myAnonymousId) => {
-  return childCommentLv2?.map((child2) => {
+  const new_child_comment_lv2 = childCommentLv2?.map((child2) => {
     const child2_user = karmaScores.find((user) => user.user_id === child2.user_id);
     if (child2.data.anon_user_info_emoji_name) {
       return {
@@ -119,6 +119,8 @@ const setChildCommentLv2 = (childCommentLv2 = [], karmaScores, mySignUserId, myA
       karmaScores: roundingKarmaScore(child2_user?.karma_score || 0)
     };
   });
+
+  return new_child_comment_lv2;
 };
 
 const handleAnonymousData = async (

--- a/utils/custom.js
+++ b/utils/custom.js
@@ -100,6 +100,27 @@ const convertLocationFromModel = (locationModel, isTO = false) => {
   return '';
 };
 
+const setChildCommentLv2 = (childCommentLv2 = [], karmaScores, mySignUserId, myAnonymousId) => {
+  return childCommentLv2?.map((child2) => {
+    const child2_user = karmaScores.find((user) => user.user_id === child2.user_id);
+    if (child2.data.anon_user_info_emoji_name) {
+      return {
+        ...child2,
+        user_id: null,
+        user: {},
+        target_feeds: [],
+        is_you: myAnonymousId === child2.user_id,
+        karmaScores: roundingKarmaScore(child2_user?.karma_score || 0)
+      };
+    }
+    return {
+      ...child2,
+      is_you: mySignUserId === child2.user_id,
+      karmaScores: roundingKarmaScore(child2_user?.karma_score || 0)
+    };
+  });
+};
+
 const handleAnonymousData = async (
   data,
   req,
@@ -113,23 +134,15 @@ const handleAnonymousData = async (
     childComment.map(async (child) => {
       const user = karmaScores.find((user) => user.user_id === child.user_id);
       if (child?.data?.anon_user_info_emoji_name) {
-        let childCommentLv2 = child?.latest_children?.comment || [];
-        childCommentLv2 = childCommentLv2?.map((child2) => {
-          const child2_user = karmaScores.find((user) => user.user_id === child2.user_id);
-          if (child2.data.anon_user_info_emoji_name) {
-            return {
-              ...child2,
-              user_id: null,
-              user: {},
-              target_feeds: [],
-              karmaScores: roundingKarmaScore(child2_user?.karma_score || 0)
-            };
-          }
-          return {...child2, karmaScores: roundingKarmaScore(child2_user?.karma_score || 0)};
-        });
+        let childCommentLv2Anon = setChildCommentLv2(
+          child?.latest_children?.comment,
+          karmaScores,
+          req.userId,
+          myAnonymousId
+        );
         return {
           ...child,
-          latest_children: {comment: childCommentLv2},
+          latest_children: {comment: childCommentLv2Anon},
           user_id: null,
           karmaScores: roundingKarmaScore(user?.karma_score || 0),
           user: {},
@@ -138,8 +151,16 @@ const handleAnonymousData = async (
           is_author: postAuthorId === child.user_id
         };
       }
+
+      let childCommentLv2 = setChildCommentLv2(
+        child?.latest_children?.comment,
+        karmaScores,
+        req.userId,
+        myAnonymousId
+      );
       return {
         ...child,
+        latest_children: {comment: childCommentLv2},
         karmaScores: roundingKarmaScore(user?.karma_score || 0),
         is_you: req.userId === child.user_id,
         is_author: child.user_id === postAuthorId


### PR DESCRIPTION
- saya tambahkan comment level v2 return is_you dan karma_score.
- dan juga saya tambahkan child comment level2 ketika user yg parentnya adalah sign user, sebelumnya hanya muncul comment level 2 ketika parent usernya anon saja

<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

- New Feature: Enhanced the handling of level 2 child comments for both anonymous and signed-in users. This update improves the accuracy of determining user ownership and karma scores, providing a more personalized and engaging user experience when interacting with nested comments.
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->