### PR TITLE
fix: ping-4010 remove attacment when type text at get channel detail

### DIFF
--- a/controllers/chat/getChannelDetail.js
+++ b/controllers/chat/getChannelDetail.js
@@ -4,6 +4,7 @@ const {User} = require('../../databases/models');
 const {ResponseSuccess} = require('../../utils/Responses');
 const UsersFunction = require('../../databases/functions/users');
 const BetterSocialCore = require('../../services/bettersocial');
+const {MESSAGE_TYPE} = require('../../helpers/constants');
 
 /**
  *
@@ -59,7 +60,15 @@ const getChannelDetail = async (req, res) => {
     better_channel_members: betterChannelMember,
     better_channel_member_objects: betterChannelMemberObject,
     ...updatedChannel,
-    messages: messages?.results?.map((message) => message?.message)
+    messages: messages?.results?.map((message) => {
+      let detail_message = message?.message;
+
+      if (detail_message.message_type === MESSAGE_TYPE.TEXT) {
+        detail_message.attachments = [];
+      }
+
+      return detail_message;
+    })
   });
 };
 


### PR DESCRIPTION
Remove attachment when message type is text at get channel detail
<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

- Bug Fix: Updated the `getChannelDetail` function in the chat controller. Now, when retrieving channel details, if a message type is 'text', any associated attachments will be removed. This ensures that text messages are displayed correctly without unnecessary attachment data, improving the clarity and readability of the chat interface.
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->