### PR TITLE
fix: ping-4062 fix discovery regarding comunity info field

### DIFF
--- a/controllers/discovery/initDiscoveryUserData.js
+++ b/controllers/discovery/initDiscoveryUserData.js
@@ -70,6 +70,10 @@ const InitDiscoveryUserData = async (req, res) => {
             A.karma_score,
             A.allow_anon_dm,
             A.only_received_dm_from_user_following,
+            ARRAY( select name from topics as tp
+              left join user_topics as utp on tp.topic_id = utp.topic_id
+              where utp.user_id = A.user_id limit 3
+            ) as community_info,
             ( select count(name) > 1 from topics as tp
 							left join user_topics as utp on tp.topic_id = utp.topic_id
 							where utp.user_id = A.user_id and tp.topic_id in (:topicIds) LIMIT 2

--- a/controllers/discovery/searchUser.js
+++ b/controllers/discovery/searchUser.js
@@ -56,6 +56,10 @@ const SearchUser = async (req, res) => {
           u.combined_user_score,
           u.karma_score,
           u.is_karma_unlocked,
+          ARRAY( select name from topics as tp
+            left join user_topics as utp on tp.topic_id = utp.topic_id
+            where utp.user_id = u.user_id limit 3
+          ) as community_info,
           (SELECT COUNT(*) FROM user_follow_user WHERE user_id_followed = u.user_id) AS followersCount,
           (
               SELECT count(name) > 1


### PR DESCRIPTION
field comunity info kemarin hilang karena saya simplyfied query ke community_info_result untuk sorting tetapi ternyata field tsb digunakan di fe, jadi saya tambahkan lagi field tersebut 
<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

- Bug Fix: Reintroduced the `community_info` field in the `InitDiscoveryUserData` and `SearchUser` functions. This change enhances user data by providing community information, improving the overall user experience on the frontend.
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->