### PR TITLE
feat: update icon and cover at topics

### DIFF
--- a/controllers/topics/index.js
+++ b/controllers/topics/index.js
@@ -12,6 +12,7 @@ const TopicService = require('../../services/postgres/TopicService');
 const TopicValidator = require('../../validators/topic');
 const topics = require('./topics');
 const checkName = require('./checkName');
+const updateTopic = require('./updateTopic');
 const create = require('./create');
 const getFollowedTopic = require('./getFollowedTopic');
 const getLatestPost = require('./getLatestPost');
@@ -400,6 +401,7 @@ module.exports = {
   topics,
   checkName,
   create,
+  updateTopic,
   putFollowTopic,
   getFollowTopic,
   getFollowedTopic,

--- a/controllers/topics/updateTopic.js
+++ b/controllers/topics/updateTopic.js
@@ -1,0 +1,60 @@
+const {Topics} = require('../../databases/models');
+
+module.exports = async (req, res) => {
+  try {
+    const {icon, cover} = req.body;
+    let {topicName} = req.params;
+    topicName = topicName.toLowerCase();
+    let response;
+
+    let topics = await Topics.findOne({
+      where: {
+        name: topicName,
+        deleted_at: null
+      }
+    });
+
+    if (!topics) {
+      response = {
+        success: false,
+        message: 'Community name not found'
+      };
+
+      return res.status(400).json(response);
+    }
+
+    if (!icon && !cover) {
+      response = {
+        code: 400,
+        success: false,
+        message: 'Please provide icon or cover'
+      };
+
+      return res.status(400).json(response);
+    }
+
+    let updateTopicData = {};
+    if (icon) {
+      updateTopicData.icon_path = icon;
+    }
+    if (cover) {
+      updateTopicData.cover_path = cover;
+    }
+
+    await Topics.update(updateTopicData, {where: {topic_id: topics.topic_id}});
+
+    response = {
+      success: true,
+      message: 'success updated topic details'
+    };
+
+    return res.status(200).json(response);
+  } catch (error) {
+    return res.json({
+      code: error.statusCode,
+      status: 'fail',
+      message: error.message,
+      data: 'null'
+    });
+  }
+};

--- a/databases/models/Topics.js
+++ b/databases/models/Topics.js
@@ -30,6 +30,7 @@ module.exports = (sequelize, DataTypes) => {
       },
       name: DataTypes.STRING,
       icon_path: DataTypes.STRING,
+      cover_path: DataTypes.STRING,
       categories: DataTypes.TEXT,
       created_at: DataTypes.DATE,
       deleted_at: DataTypes.DATE,

--- a/joi-validations/general.validations.js
+++ b/joi-validations/general.validations.js
@@ -4,6 +4,7 @@ const Joi = require('joi');
 const string = Joi.string().trim();
 const uuid = string.uuid();
 const number = Joi.number();
+const url = string.uri().trim();
 const boolean = Joi.boolean();
 const dateIso = Joi.date().iso();
 const array = (item) => Joi.array().items(item);
@@ -11,6 +12,7 @@ const object = (keys) => Joi.object().keys(keys);
 
 module.exports = {
   string,
+  url,
   number,
   boolean,
   dateIso,

--- a/joi-validations/topics.validations.js
+++ b/joi-validations/topics.validations.js
@@ -1,9 +1,15 @@
-const {string} = require('./general.validations');
+const {string, url} = require('./general.validations');
 
 const TopicValidation = {
   latestPost: {
     query: {
       name: string.required()
+    }
+  },
+  updateTopic: {
+    body: {
+      icon: url,
+      cover: url
     }
   },
   checkName: {

--- a/routes/topics.js
+++ b/routes/topics.js
@@ -16,6 +16,12 @@ router.get('/follow', isAuth, topicsController.getFollowTopic);
 router.get('/latest', validate(TopicValidation.latestPost), isAuth, topicsController.getLatestPost);
 router.put('/follow', isAuth, topicsController.putFollowTopic);
 router.put('/follow-v2', isAuth, topicsController.followTopicV2);
+router.put(
+  '/:topicName',
+  validate(TopicValidation.updateTopic),
+  isAuth,
+  topicsController.updateTopic
+);
 router.get('/is-exist', validate(TopicValidation.checkName), isAuth, topicsController.checkName);
 router.post('/create', validate(TopicValidation.create), isAuth, topicsController.create);
 router.get('/', isAuth, topicsController.getTopics);


### PR DESCRIPTION
Update icon dan cover di topics detail
<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

- New Feature: Added the ability to update the icon and cover of a topic. Users can now modify these elements using a new PUT request route.
- Update: Enhanced input validation for updating topics. The system now ensures that both `icon` and `cover` inputs are valid URLs before processing updates.
- Update: Extended the `Topics` database model to include a `cover_path` field, enabling storage of cover image paths for each topic.
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->