### PR TITLE
fix: only topic with >= 5 follower show at sugestions

### DIFF
--- a/controllers/topics/index.js
+++ b/controllers/topics/index.js
@@ -132,6 +132,7 @@ const getTopics = async (req, res) => {
                 "Topic"."name" ILIKE :likeQuery
             GROUP BY 
                 "Topic"."topic_id"
+            HAVING count("topicFollower"."user_id") >= 5
             ORDER BY
                 "followersCount" DESC
             LIMIT 50`,


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

- New Feature: Updated the 'getTopics' functionality in the Topics Controller. Now, it only returns topics that have at least 5 followers. This enhancement ensures users are presented with more popular and relevant topics, improving their browsing experience.
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->