### PR TITLE
feat: ping-4093 add delay time to queue

### DIFF
--- a/controllers/topics/index.js
+++ b/controllers/topics/index.js
@@ -342,7 +342,12 @@ const _topicAutoMessage = async (user_id, topic_id, detailTokenUser) => {
     });
     if (communityMessageFormats && !detailTokenUser.is_anonymous) {
       for (const format of communityMessageFormats) {
-        followTopicServiceQueue(user_id, topic_id, format.delay_time);
+        followTopicServiceQueue(
+          user_id,
+          topic_id,
+          format.community_message_format_id,
+          format.delay_time
+        );
       }
     }
   } catch (error) {

--- a/controllers/topics/index.js
+++ b/controllers/topics/index.js
@@ -337,12 +337,13 @@ const followTopicV2 = async (req, res) => {
 
 const _topicAutoMessage = async (user_id, topic_id, detailTokenUser) => {
   try {
-    const communityMessageFormat = await CommunityMessageFormat.findOne({
+    const communityMessageFormats = await CommunityMessageFormat.findAll({
       where: {topic_id, status: '1'}
     });
-
-    if (communityMessageFormat && !detailTokenUser.is_anonymous) {
-      followTopicServiceQueue(user_id, topic_id);
+    if (communityMessageFormats && !detailTokenUser.is_anonymous) {
+      for (const format of communityMessageFormats) {
+        followTopicServiceQueue(user_id, topic_id, format.delay_time);
+      }
     }
   } catch (error) {
     console.log(error);

--- a/services/redis/queue.js
+++ b/services/redis/queue.js
@@ -1,5 +1,7 @@
 const Bull = require('bull');
 const {v4: uuidv4} = require('uuid');
+const momentTz = require('moment-timezone');
+const {sample} = require('lodash');
 
 const {convertingUserFormatForLocation} = require('../../utils/custom');
 const {bullConfig, redisUrl} = require('../../config/redis');
@@ -57,15 +59,27 @@ const registerV2ServiceQueue = async (token, userId, follows, topics, locations,
   }
 };
 
-const followTopicServiceQueue = async (user_id, topic_id) => {
+const followTopicServiceQueue = async (user_id, topic_id, delay) => {
   const data = {
     user_id,
     topic_id
   };
 
+  let currentTime = momentTz().tz('America/Los_Angeles');
+  const randomTime = sample([6, 7, 8]);
+  const additionalDays = delay;
+
+  let requiredTime = momentTz()
+    .tz('America/Los_Angeles')
+    .set({hour: randomTime})
+    .add(additionalDays, 'days');
+
+  const diffTime = requiredTime.diff(currentTime, 'milliseconds');
+
   const options = {
     jobId: uuidv4(),
-    removeOnComplete: true
+    removeOnComplete: true,
+    delay: diffTime
   };
   try {
     await followTopicQueue.add(data, options);

--- a/services/redis/queue.js
+++ b/services/redis/queue.js
@@ -59,12 +59,12 @@ const registerV2ServiceQueue = async (token, userId, follows, topics, locations,
   }
 };
 
-const followTopicServiceQueue = async (user_id, topic_id, delay) => {
+const followTopicServiceQueue = async (user_id, topic_id, community_message_format_id, delay) => {
   const data = {
     user_id,
-    topic_id
+    topic_id,
+    community_message_format_id
   };
-
   let currentTime = momentTz().tz('America/Los_Angeles');
   const randomTime = sample([6, 7, 8]);
   const additionalDays = delay;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

- New Feature: Enhanced the `followTopicServiceQueue` function in `services/redis/queue.js` to support delayed task execution. This allows for more flexible scheduling of tasks based on community message formats.
- Refactor: Updated `_topicAutoMessage` in `controllers/topics/index.js` to iterate over all `communityMessageFormats` and schedule tasks with varying delay times. This ensures that each community message format is processed at its designated time.
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->