### PR TITLE
feat: remove admin user from search result

### DIFF
--- a/controllers/discovery/initDiscoveryUserData.js
+++ b/controllers/discovery/initDiscoveryUserData.js
@@ -107,6 +107,7 @@ const InitDiscoveryUserData = async (req, res) => {
           AND A.is_anonymous = false 
           AND A.is_banned = false
           AND A.karma_score > :minimumKarmaScore
+          AND A.user_id != :admin_user_id
           ${where_anon_dm} 
           ${filterBlockedUser}
         ORDER BY
@@ -125,7 +126,8 @@ const InitDiscoveryUserData = async (req, res) => {
         allow_anon_dm,
         limit: limit,
         offset: page * limit,
-        minimumKarmaScore: MINIMUM_KARMA_SCORE
+        minimumKarmaScore: MINIMUM_KARMA_SCORE,
+        admin_user_id: process.env.BETTER_ADMIN_ID
       }
     });
     let suggestedUsers = usersWithCommonFollowerResult;

--- a/controllers/discovery/searchUser.js
+++ b/controllers/discovery/searchUser.js
@@ -87,6 +87,7 @@ const SearchUser = async (req, res) => {
           AND u.user_id != :userId
           AND u.is_anonymous = false
           AND u.is_banned = false
+          AND u.user_id != :admin_user_id
           AND u.verified_status != 'UNVERIFIED') 
       ORDER BY  
           recently_active DESC,
@@ -101,6 +102,7 @@ const SearchUser = async (req, res) => {
           allow_anon_dm,
           userId,
           minimumKarmaScore: MINIMUM_KARMA_SCORE,
+          admin_user_id: process.env.BETTER_ADMIN_ID,
           limit
         }
       }


### PR DESCRIPTION
need review for remove admin user from search result
<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

- Bug Fix: Updated the user discovery and search functionality to exclude the admin user from search results. This change enhances the privacy and security of the admin account by preventing it from appearing in user searches. The admin user ID is now configurable through the `BETTER_ADMIN_ID` environment variable.
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->