### PR TITLE
feat: ping-4017 Sort comments by created date in detailFeed controller

### DIFF
--- a/controllers/feeds/detailFeed.js
+++ b/controllers/feeds/detailFeed.js
@@ -40,7 +40,12 @@ module.exports = async (req, res) => {
     if (comment?.user?.id && !actors.includes(comment.user.id)) {
       actors.push(comment.user.id);
     }
-    comment?.latest_children?.comment?.forEach(collectUserIds);
+    comment?.latest_children?.comment
+      ?.sort((a, b) => new Date(a.created_at) - new Date(b.created_at))
+      .forEach(collectUserIds);
+    comment?.own_children?.comment
+      ?.sort((a, b) => new Date(a.created_at) - new Date(b.created_at))
+      .forEach(collectUserIds);
   };
   comments.forEach(collectUserIds);
 


### PR DESCRIPTION
This commit modifies the detailFeed controller to sort comments by their created date. This ensures that the comments are displayed in the correct chronological order. The `comment.latest_children.comment` and `comment.own_children.comment` arrays are sorted using the `created_at` property. This change improves the organization and readability of the comments section in the feed.
<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

- Enhancement: Improved the comment display order in the feed details. Comments are now sorted by their creation date, providing a more intuitive and chronological view of discussions. This change affects both `comment.latest_children.comment` and `comment.own_children.comment` arrays in the `detailFeed` controller.
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->