### PR TITLE
fix: disable updating better_channel_member for group channel

### DIFF
--- a/controllers/chat/findOrCreateChannelBySignedSender.js
+++ b/controllers/chat/findOrCreateChannelBySignedSender.js
@@ -45,12 +45,18 @@ const findOrCreateChannelBySignedSender = async (req, res) => {
       }
     }
 
+    const shouldBetterChannelMembersUpdated = channelType !== CHANNEL_TYPE.GROUP;
     const findOrCreateChannel = await channel.create();
     const {betterChannelMember, newChannelName, betterChannelMemberObject, updatedChannel} =
-      await BetterSocialCore.chat.updateBetterChannelMembers(channel, findOrCreateChannel, true, {
-        channelType,
-        channel_type: channelType
-      });
+      await BetterSocialCore.chat.updateBetterChannelMembers(
+        channel,
+        findOrCreateChannel,
+        shouldBetterChannelMembersUpdated,
+        {
+          channelType,
+          channel_type: channelType
+        }
+      );
 
     findOrCreateChannel.channel.name = newChannelName;
 

--- a/controllers/chat/getChannelDetail.js
+++ b/controllers/chat/getChannelDetail.js
@@ -4,7 +4,7 @@ const {User} = require('../../databases/models');
 const {ResponseSuccess} = require('../../utils/Responses');
 const UsersFunction = require('../../databases/functions/users');
 const BetterSocialCore = require('../../services/bettersocial');
-const {MESSAGE_TYPE} = require('../../helpers/constants');
+const {MESSAGE_TYPE, CHANNEL_TYPE} = require('../../helpers/constants');
 
 /**
  *
@@ -53,8 +53,14 @@ const getChannelDetail = async (req, res) => {
     });
   }
 
+  const shouldBetterChannelMembersUpdated = channel_type !== CHANNEL_TYPE.GROUP;
+
   const {betterChannelMember, betterChannelMemberObject, updatedChannel} =
-    await BetterSocialCore.chat.updateBetterChannelMembers(channel, createdChannel, true);
+    await BetterSocialCore.chat.updateBetterChannelMembers(
+      channel,
+      createdChannel,
+      shouldBetterChannelMembersUpdated
+    );
 
   return ResponseSuccess(res, 'Success', 200, {
     better_channel_members: betterChannelMember,

--- a/controllers/chat/group/groupAddMembers.js
+++ b/controllers/chat/group/groupAddMembers.js
@@ -96,7 +96,7 @@ const groupAddMembers = async (req, res) => {
         await BetterSocialCore.chat.updateBetterChannelMembers(
           channelToAdd,
           responseChannel,
-          true,
+          false,
           {
             channelType: CHANNEL_TYPE.GROUP,
             channel_type: CHANNEL_TYPE.GROUP

--- a/controllers/chat/group/leaveGroupMember.js
+++ b/controllers/chat/group/leaveGroupMember.js
@@ -54,7 +54,7 @@ const leaveGroupMember = async (req, res) => {
     const {channel, channelApiResponse} = response.data || {};
 
     const {newChannelName, betterChannelMember, betterChannelMemberObject, updatedChannel} =
-      await BetterSocialCore.chat.updateBetterChannelMembers(channel, channelApiResponse, true);
+      await BetterSocialCore.chat.updateBetterChannelMembers(channel, channelApiResponse, false);
 
     channelResponse = updatedChannel;
 

--- a/controllers/chat/group/removeGroupMember.js
+++ b/controllers/chat/group/removeGroupMember.js
@@ -57,7 +57,7 @@ const removeGroupMember = async (req, res) => {
     let channelResponse;
     try {
       const {newChannelName, betterChannelMember, betterChannelMemberObject, updatedChannel} =
-        await BetterSocialCore.chat.updateBetterChannelMembers(channel, channelApiResponse, true);
+        await BetterSocialCore.chat.updateBetterChannelMembers(channel, channelApiResponse, false);
 
       await BetterSocialCore.fcmToken.sendGroupChatNotification(
         targetUserModel.user_id,

--- a/databases/config/database.js
+++ b/databases/config/database.js
@@ -14,7 +14,8 @@ module.exports = {
     define: {
       timestamps: true,
       freezeTableName: true
-    }
+    },
+    logging: false
   },
   staging: {
     username: process.env.DB_USERNAME,


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

- Refactor: Updated the logic in various chat controllers to conditionally update better channel members based on the channel type. This change enhances the efficiency of group channel operations.
- Chore: Modified the database configuration to disable logging, resulting in cleaner console output during application execution. This change does not affect end-user functionality but improves the developer experience.
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->