### PR TITLE
fix: cannot set headers after they are sent to the client

### DIFF
--- a/controllers/topics/getLatestPost.js
+++ b/controllers/topics/getLatestPost.js
@@ -17,6 +17,8 @@ module.exports = async (req, res) => {
         code: 400,
         message: 'Topic not found'
       });
+
+      return;
     }
 
     const feedClient = stream.connect(process.env.API_KEY, process.env.SECRET, process.env.APP_ID);


### PR DESCRIPTION
https://bettersocial.sentry.io/issues/5216194856/?environment=production&project=4506585409519616&query=is:unresolved+issue.priority:%5Bhigh,+medium%5D&statsPeriod=14d&stream_index=5
<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

- Bug Fix: Updated the error handling in `getLatestPost.js` under the topics controller. Now, when a topic is not found, the function will immediately return after sending an error response, preventing any further execution. This ensures that our API behaves more predictably and robustly when encountering missing topics.
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->