### PR TITLE
feat: 4343 don't send notif if cooment user == post user

### DIFF
--- a/services/bettersocial/post/commentChild.js
+++ b/services/bettersocial/post/commentChild.js
@@ -151,13 +151,14 @@ const BetterSocialCreateCommentChildV3 = async (req) => {
       await countProcess(reaction_id, {comment_count: +1}, {comment_count: 1});
     }
 
-    await sendMultiDeviceReplyCommentNotification(
-      signedUserIdFeed,
-      req.user,
-      message,
-      reaction_id,
-      postTitle
-    );
+    if (!(await UsersFunction.checkIsMe(User, signedUserIdFeed, userId)))
+      await sendMultiDeviceReplyCommentNotification(
+        signedUserIdFeed,
+        req.user,
+        message,
+        reaction_id,
+        postTitle
+      );
 
     QueueTrigger.addCommentToDb({
       postId: result?.activity_id,
@@ -221,14 +222,14 @@ const BetterSocialCreateCommentChildV3Anonymous = async (req) => {
     if (body?.message?.length > 80) {
       await countProcess(reaction_id, {comment_count: +1}, {comment_count: 1});
     }
-
-    await sendMultiDeviceReplyCommentNotification(
-      signedUserIdFeed,
-      commentAuthor,
-      message,
-      reaction_id,
-      postTitle
-    );
+    if (!(await UsersFunction.checkIsMe(User, signedUserIdFeed, userId)))
+      await sendMultiDeviceReplyCommentNotification(
+        signedUserIdFeed,
+        commentAuthor,
+        message,
+        reaction_id,
+        postTitle
+      );
 
     QueueTrigger.addCommentToDb({
       postId: result?.activity_id,


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

- Bug Fix: Updated the `BetterSocialCreateCommentChildV3` and `BetterSocialCreateCommentChildV3Anonymous` functions in the BetterSocial service. These changes ensure that notifications are only sent when the user commenting is different from the post's author, preventing unnecessary notifications and enhancing user experience.
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->