### PR TITLE
feat: remove main_feed_broad from getFeeds

### DIFF
--- a/controllers/feeds/getFeedsV2.js
+++ b/controllers/feeds/getFeedsV2.js
@@ -39,8 +39,6 @@ const feedSwitch = async (feed) => {
     case 'main_feed_following':
       return 'main_feed_f2';
     case 'main_feed_f2':
-      return 'main_feed_broad';
-    case 'main_feed_broad':
       return 'main_feed';
     default:
       return 'main_feed_following';

--- a/services/getstream/getUnfilteredActivities.js
+++ b/services/getstream/getUnfilteredActivities.js
@@ -18,8 +18,6 @@ const feedSwitch = async (feed) => {
     case 'main_feed_following':
       return 'main_feed_f2';
     case 'main_feed_f2':
-      return 'main_feed_broad';
-    case 'main_feed_broad':
       return 'main_feed';
     default:
       return 'main_feed_following';


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

---
- Refactor: Simplified the feed retrieval logic by removing the 'main_feed_broad' case in the `feedSwitch` function. This change streamlines the process and now redirects directly to 'main_feed'. Please note, this may subtly alter the content displayed in the main feed.
---
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->